### PR TITLE
feat: migrate to new set_output

### DIFF
--- a/.github/workflows/build_docker_image_and_push_to_ecr.yaml
+++ b/.github/workflows/build_docker_image_and_push_to_ecr.yaml
@@ -164,12 +164,12 @@ jobs:
         run: |
           if [ "${{ job.status }}" = "success" ]
           then
-              echo ::set-output name=color::#00cc00
-              echo ::set-output name=emoji::large_green_circle
+              echo "color=#00cc00" >> $GITHUB_OUTPUT
+              echo "emoji=large_green_circle" >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=color::#ff0000
-              echo ::set-output name=emoji::red_circle
-          fi 
+              echo "color=#ff0000" >> $GITHUB_OUTPUT
+              echo "emoji=red_circle" >> $GITHUB_OUTPUT
+          fi
       
       - name: send result to slack
         if: always() && inputs.slackChannelId != ''

--- a/.github/workflows/create_changelog.yaml
+++ b/.github/workflows/create_changelog.yaml
@@ -149,7 +149,7 @@ jobs:
         run: |
           echo "${{ steps.changelog.outputs.changelog }}" | sed 's/\*\*/\*/g' | sed 's/\* /• /g' > changelog.txt
           changelog=$(awk '{printf "%s\\n", $0}' changelog.txt)
-          echo ::set-output name=changelog::$changelog
+          echo "changelog=${changelog}" >> $GITHUB_OUTPUT
       
       - name: send changelog to slack
         if: ${{ fromJSON(steps.release.outputs.result).alreadyExists == false && inputs.slackChannelId != '' }}

--- a/.github/workflows/deploy_cloudformation.yaml
+++ b/.github/workflows/deploy_cloudformation.yaml
@@ -175,11 +175,11 @@ jobs:
         run: |
           if [ "${{ job.status }}" = "success" ]
           then
-              echo ::set-output name=color::#00cc00
-              echo ::set-output name=emoji::large_green_circle
+              echo "color=#00cc00" >> $GITHUB_OUTPUT
+              echo "emoji=large_green_circle" >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=color::#ff0000
-              echo ::set-output name=emoji::red_circle
+              echo "color=#ff0000" >> $GITHUB_OUTPUT
+              echo "emoji=red_circle" >> $GITHUB_OUTPUT
           fi
       
       - name: send result to slack

--- a/.github/workflows/deploy_helmfile.yaml
+++ b/.github/workflows/deploy_helmfile.yaml
@@ -183,11 +183,11 @@ jobs:
         run: |
           if [ "${{ job.status }}" = "success" ]
           then
-              echo ::set-output name=color::#00cc00
-              echo ::set-output name=emoji::large_green_circle
+              echo "color=#00cc00" >> $GITHUB_OUTPUT
+              echo "emoji=large_green_circle" >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=color::#ff0000
-              echo ::set-output name=emoji::red_circle
+              echo "color=#ff0000" >> $GITHUB_OUTPUT
+              echo "emoji=red_circle" >> $GITHUB_OUTPUT
           fi 
       
       - name: send result to slack

--- a/.github/workflows/get_values.yaml
+++ b/.github/workflows/get_values.yaml
@@ -36,7 +36,7 @@ jobs:
               COMMIT_SHA=${{ github.sha }}
           fi
           echo "SHORT_COMMIT_SHA=${COMMIT_SHA::10}" >> $GITHUB_ENV
-          echo "::set-output name=short_commit_sha::${COMMIT_SHA::10}"
+          echo "short_commit_sha=${COMMIT_SHA::10}" >> $GITHUB_OUTPUT
 
       - name: get last commit author  
         uses: actions/github-script@v6

--- a/.github/workflows/slack.yaml
+++ b/.github/workflows/slack.yaml
@@ -56,10 +56,10 @@ jobs:
               revision=${{ inputs.revision }}
           fi
 
-          echo ::set-output name=color::${color}
-          echo ::set-output name=emoji::${emoji}
-          echo ::set-output name=revision::${revision}
-          echo ::set-output name=jobStatus::${jobStatus}
+          echo "color=${color}" >> $GITHUB_OUTPUT
+          echo "emoji=${emoji}" >> $GITHUB_OUTPUT
+          echo "revision=${revision}" >> $GITHUB_OUTPUT
+          echo "jobStatus=${jobStatus}" >> $GITHUB_OUTPUT
 
       - name: send message
         uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -141,12 +141,12 @@ jobs:
         run: |
           if [ "${{ job.status }}" = "success" ]
           then
-              echo ::set-output name=color::#00cc00
-              echo ::set-output name=emoji::large_green_circle
+              echo "color=#00cc00" >> $GITHUB_OUTPUT
+              echo "emoji=large_green_circle" >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=color::#ff0000
-              echo ::set-output name=emoji::red_circle
-          fi 
+              echo "color=#ff0000" >> $GITHUB_OUTPUT
+              echo "emoji=red_circle" >> $GITHUB_OUTPUT
+          fi
 
       - name: send result to slack
         if: always() && inputs.slackChannelId != ''


### PR DESCRIPTION
Per deprecation notice. Migrating all `::set-output` to `echo "xxx" > $GITHUB_OUTPUT`