### PR TITLE
chore: update `configure-aws-credentials` action to Node 16

### DIFF
--- a/.github/workflows/deploy_cloudformation.yaml
+++ b/.github/workflows/deploy_cloudformation.yaml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: assume IAM role
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.awsAccessKeyId }}
           aws-secret-access-key: ${{ secrets.awsSecretAccessKey }}

--- a/.github/workflows/deploy_helmfile.yaml
+++ b/.github/workflows/deploy_helmfile.yaml
@@ -154,7 +154,7 @@ jobs:
 
       - name: assume IAM role
         if: inputs.awsRoleArn != ''
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.awsAccessKeyId }}
           aws-secret-access-key: ${{ secrets.awsSecretAccessKey }}

--- a/.github/workflows/invalidate_cloudfront.yaml
+++ b/.github/workflows/invalidate_cloudfront.yaml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: assume IAM role
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.awsAccessKeyId }}
           aws-secret-access-key: ${{ secrets.awsSecretAccessKey }}


### PR DESCRIPTION
To get rid of these warnings:
<img width="1194" alt="Screenshot 2023-04-26 at 10 25 14" src="https://user-images.githubusercontent.com/2934111/234515908-4b105f80-eeb6-4083-8c08-675a35eb0ee0.png">
