### PR TITLE
chore: Update `cfn-lint` in CloudFormation lint workflow

### DIFF
--- a/.github/workflows/lint_cloudformation.yaml
+++ b/.github/workflows/lint_cloudformation.yaml
@@ -17,7 +17,7 @@ on:
 
 env:
   # renovate: datasource=pypi depName=cfn-lint
-  CFN_LINT_VERSION: v0.76.1
+  CFN_LINT_VERSION: v0.79.11
 
 jobs:
   lint:


### PR DESCRIPTION
I need to update `cfn-lint` because it contains updated definitions for allowed ElastiCache instances.