### PR TITLE
Fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ on:
 
 jobs:
   get_values:
-    uses: apify/workflows/.github/workflows/get_values.yaml
+    uses: apify/workflows/.github/workflows/get_values.yaml@main
   
   build:
     needs: get_values
-    uses: apify/workflows/.github/workflows/build_docker_image_and_push_to_ecr.yaml
+    uses: apify/workflows/.github/workflows/build_docker_image_and_push_to_ecr.yaml@main
     secrets:
       awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
       awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
```
{owner}/{repo}/.github/workflows/{filename}@{ref} for reusable workflows in public and private repositories.
```

https://docs.github.com/en/actions/sharing-automations/reusing-workflows#calling-a-reusable-workflow