### PR TITLE
chore: make scope bolded and without wrapping in `()`

### DIFF
--- a/git-cliff-release/cliff.toml
+++ b/git-cliff-release/cliff.toml
@@ -28,7 +28,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | striptags | trim | upper_first }}
     {% for commit in commits %}
-        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+        - {% if commit.scope %}**{{ commit.scope }}** {% endif %}\
             {% if commit.breaking %}[**breaking**] {% endif %}\
             {% if commit.extra.pr_link %}\
             {{ commit.message | upper_first | replace(from=commit.extra.raw_pr_link, to=commit.extra.pr_link) }}\


### PR DESCRIPTION
Before, a scope will be rendered as `*(<scope>)*`. With this PR, it will be rendered as `**<scope>**`