### PR TITLE
feat: Wait until Tailscale is ready in the deploy workflow

### DIFF
--- a/.github/workflows/deploy_helmfile.yaml
+++ b/.github/workflows/deploy_helmfile.yaml
@@ -201,6 +201,14 @@ jobs:
       - name: setup kubeconfig
         run: aws eks update-kubeconfig --name ${{ inputs.eksClusterName }} $OPTIONAL_PARAMS
 
+      - name: wait until Tailscale is ready
+        if: inputs.enableVpn == 'true'
+        run: |
+          for i in {1..20}; do
+            kubectl cluster-info --request-timeout 3 && break
+            echo "Waiting for Tailscale to be ready..."
+          done
+
       - name: helmfile ${{ inputs.helmfileCommand }}
         run: |
           export $(echo ${{ inputs.envVariables }})


### PR DESCRIPTION
This adds a dynamic wait to the Tailscale setup so that the workflow continues only when the K8S cluster becomes reachable.