### PR TITLE
feat: `no-github` input option for `git-cliff-release`

### DIFF
--- a/git-cliff-release/action.yaml
+++ b/git-cliff-release/action.yaml
@@ -107,7 +107,7 @@ runs:
         set -x
         enhance_context_args=()
 
-        if (( ${{ inputs.no-github }} )); then
+        if [[ ${{ inputs.no-github }} = true ]]; then
           enhance_context_args+=(--no-github)
         fi
 
@@ -146,7 +146,7 @@ runs:
           print_changelog_args+=(--output "$out_file")
         fi
 
-        if (( ${{ inputs.no-github }} )); then
+        if [[ ${{ inputs.no-github }} = true ]]; then
           enhance_context_args+=(--no-github)
         fi
 

--- a/git-cliff-release/action.yaml
+++ b/git-cliff-release/action.yaml
@@ -33,6 +33,11 @@ inputs:
     required: false
     type: string
     default: ${{ github.token }}
+  no-github:
+    description: If set to true, the action will not insert links to GitHub issues and PRs in the release notes and changelog.
+    required: false
+    type: boolean
+    default: false
 outputs:
   is_prerelease:
     description: For convenience - was the action triggered with release_type = "prerelease"?
@@ -102,7 +107,12 @@ runs:
         set -x
         echo 'release_notes<<EOF' >> $GITHUB_OUTPUT
         git-cliff --tag "${{ steps.version_number.outputs.tag_name }}" --unreleased --context | 
-          python enhance_context.py --repo $GITHUB_REPO --release-notes | 
+          {
+            if [[ ${{ inputs.no-github }} = true ]];
+              then cat;
+              else python enhance_context.py --repo $GITHUB_REPO --release-notes;
+            fi;
+          } |
           git-cliff --from-context - --strip all |
           tee -a $GITHUB_OUTPUT
         echo 'EOF' >> $GITHUB_OUTPUT
@@ -142,7 +152,12 @@ runs:
         fi
 
         git-cliff --context "${dump_context_args[@]}" |
-          python enhance_context.py --repo $GITHUB_REPO "${enhance_context_args[@]}" |
+          { 
+            if [[ ${{ inputs.no-github }} = true ]];
+              then cat; 
+              else python enhance_context.py --repo $GITHUB_REPO "${enhance_context_args[@]}";
+            fi; 
+          } |
           git-cliff --from-context - "${print_changelog_args[@]}"
 
         sed -i '$a\' $out_file # Make sure there is a newline at the end of the output file

--- a/git-cliff-release/action.yaml
+++ b/git-cliff-release/action.yaml
@@ -33,11 +33,11 @@ inputs:
     required: false
     type: string
     default: ${{ github.token }}
-  no-github:
-    description: If set to true, the action will not insert links to GitHub issues and PRs in the release notes and changelog.
+  add-github-links:
+    description: If set to false, the action will not insert links to GitHub issues and PRs in the release notes and changelog.
     required: false
     type: boolean
-    default: false
+    default: true
 outputs:
   is_prerelease:
     description: For convenience - was the action triggered with release_type = "prerelease"?
@@ -107,7 +107,7 @@ runs:
         set -x
         enhance_context_args=()
 
-        if [[ ${{ inputs.no-github }} = true ]]; then
+        if [[ ${{ inputs.add-github-links }} = false ]]; then
           enhance_context_args+=(--no-github)
         fi
 
@@ -146,7 +146,7 @@ runs:
           print_changelog_args+=(--output "$out_file")
         fi
 
-        if [[ ${{ inputs.no-github }} = true ]]; then
+        if [[ ${{ inputs.add-github-links }} = false ]]; then
           enhance_context_args+=(--no-github)
         fi
 

--- a/git-cliff-release/action.yaml
+++ b/git-cliff-release/action.yaml
@@ -105,14 +105,15 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         set -x
+        enhance_context_args=()
+
+        if (( ${{ inputs.no-github }} )); then
+          enhance_context_args+=(--no-github)
+        fi
+
         echo 'release_notes<<EOF' >> $GITHUB_OUTPUT
         git-cliff --tag "${{ steps.version_number.outputs.tag_name }}" --unreleased --context | 
-          {
-            if [[ ${{ inputs.no-github }} = true ]];
-              then cat;
-              else python enhance_context.py --repo $GITHUB_REPO --release-notes;
-            fi;
-          } |
+          python enhance_context.py --repo $GITHUB_REPO --release-notes "${enhance_context_args[@]}" |
           git-cliff --from-context - --strip all |
           tee -a $GITHUB_OUTPUT
         echo 'EOF' >> $GITHUB_OUTPUT
@@ -145,6 +146,10 @@ runs:
           print_changelog_args+=(--output "$out_file")
         fi
 
+        if (( ${{ inputs.no-github }} )); then
+          enhance_context_args+=(--no-github)
+        fi
+
         if [[ ${{ inputs.release_type }} = prerelease ]]; then
           enhance_context_args+=(--unreleased-version "${{ steps.version_number.outputs.tag_name }}")
         else
@@ -152,12 +157,7 @@ runs:
         fi
 
         git-cliff --context "${dump_context_args[@]}" |
-          { 
-            if [[ ${{ inputs.no-github }} = true ]];
-              then cat; 
-              else python enhance_context.py --repo $GITHUB_REPO "${enhance_context_args[@]}";
-            fi; 
-          } |
+          python enhance_context.py --repo $GITHUB_REPO "${enhance_context_args[@]}" |
           git-cliff --from-context - "${print_changelog_args[@]}"
 
         sed -i '$a\' $out_file # Make sure there is a newline at the end of the output file

--- a/git-cliff-release/cliff.toml
+++ b/git-cliff-release/cliff.toml
@@ -36,10 +36,10 @@ body = """
             {{ commit.message | escape | upper_first }}\
             {% endif %}\
             {% if commit.extra.commit_link %} ([{{ commit.id | truncate(length = 7, end = "") }}]({{ commit.extra.commit_link }})){% endif %}\
-            {% if commit.remote.username and extra.is_release_notes %}\
-            {{" "}}by @{{ commit.remote.username }}\
-            {% elif not extra.no_github and commit.remote.username %}\
-            {{" "}}by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }})\
+            {% if commit.extra.username and extra.is_release_notes %}\
+            {{" "}}by @{{ commit.extra.username }}\
+            {% elif commit.extra.username %}\
+            {{" "}}by [@{{ commit.extra.username }}](https://github.com/{{ commit.extra.username }})\
             {% if commit.extra.closed_issue_links %}\
             , closes {{ commit.extra.closed_issue_links | join(sep = ", ") }}\
             {% endif %}\

--- a/git-cliff-release/cliff.toml
+++ b/git-cliff-release/cliff.toml
@@ -38,7 +38,7 @@ body = """
             {% if commit.extra.commit_link %} ([{{ commit.id | truncate(length = 7, end = "") }}]({{ commit.extra.commit_link }})){% endif %}\
             {% if commit.remote.username and extra.is_release_notes %}\
             {{" "}}by @{{ commit.remote.username }}\
-            {% elif commit.remote.username %}\
+            {% elif not extra.no_github and commit.remote.username %}\
             {{" "}}by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }})\
             {% if commit.extra.closed_issue_links %}\
             , closes {{ commit.extra.closed_issue_links | join(sep = ", ") }}\

--- a/git-cliff-release/enhance_context.py
+++ b/git-cliff-release/enhance_context.py
@@ -83,14 +83,11 @@ if __name__ == "__main__":
     pr_issues = load_pr_issues(owner, repo)
     context = json.load(sys.stdin)
 
-    for release in context:
-        if args.no_github:
-            release["extra"] = { 'no_github': True }
-            continue
+    if not args.no_github:    
+        for release in context:
+            enhance_release(release, args.release_notes, args.unreleased_version)
 
-        enhance_release(release, args.release_notes, args.unreleased_version)
-
-        for commit in release["commits"]:
-            enhance_commit(commit, pr_issues)
+            for commit in release["commits"]:
+                enhance_commit(commit, pr_issues)
 
     json.dump(context, sys.stdout)

--- a/git-cliff-release/enhance_context.py
+++ b/git-cliff-release/enhance_context.py
@@ -66,7 +66,7 @@ parser = ArgumentParser()
 parser.add_argument("--repo", type=str, required=True)
 parser.add_argument("--unreleased-version", nargs="?", default=None, type=str)
 parser.add_argument("--release-notes", action=BooleanOptionalAction)
-parser.add_argument("--no-github", type=bool, required=False, default=False)
+parser.add_argument("--no-github", default=False, action="store_true")
 
 
 if __name__ == "__main__":

--- a/git-cliff-release/enhance_context.py
+++ b/git-cliff-release/enhance_context.py
@@ -66,6 +66,7 @@ parser = ArgumentParser()
 parser.add_argument("--repo", type=str, required=True)
 parser.add_argument("--unreleased-version", nargs="?", default=None, type=str)
 parser.add_argument("--release-notes", action=BooleanOptionalAction)
+parser.add_argument("--no-github", type=bool, required=False, default=False)
 
 
 if __name__ == "__main__":
@@ -77,6 +78,10 @@ if __name__ == "__main__":
     context = json.load(sys.stdin)
 
     for release in context:
+        if args.no_github:
+            release["extra"] = { 'no_github': True }
+            continue
+
         enhance_release(release, args.release_notes, args.unreleased_version)
 
         for commit in release["commits"]:

--- a/git-cliff-release/enhance_context.py
+++ b/git-cliff-release/enhance_context.py
@@ -44,10 +44,16 @@ def enhance_release(
 
 
 def enhance_commit(commit: dict[str, Any], pr_issues: dict[int, list[int]]) -> None:
-    pr_number = commit.get("remote", {}).get("pr_number")
+    commit_remote = commit.get("remote", {})
+
+    pr_number = commit_remote.get("pr_number")
+    username = commit_remote.get("username")
 
     commit["extra"] = commit["extra"] or {}
     commit["extra"]["commit_link"] = f"{repo_url}/commit/{commit['id']}"
+
+    if username:
+        commit["extra"]["username"] = username
 
     if pr_number:
         commit["extra"]["closed_issues"] = pr_issues.get(pr_number, [])


### PR DESCRIPTION
Passing the `--no-github` Action option removes all links (PR, issues...) and user mentions leading to GitHub. This can be useful for closed-source projects, where those links would result in 403 anyway. 

Tested in this [WCC branch](https://github.com/apify/store-website-content-crawler/actions/workflows/changelog-playground.yaml).