### PR TITLE
chore: add timestamp for no-link releases

### DIFF
--- a/git-cliff-release/cliff.toml
+++ b/git-cliff-release/cliff.toml
@@ -21,7 +21,7 @@ body = """
 {% elif extra.unreleased_version %}\
     ## {{ extra.unreleased_version | trim_start_matches(pat="v") }} - **not yet released**
 {% elif version %}
-    ## {{ version | trim_start_matches(pat="v") }}
+    ## {{ version | trim_start_matches(pat="v") }} ({{ timestamp | date(format="%Y-%m-%d") }})
 {% else %}\
     ## Unreleased
 {% endif %}\


### PR DESCRIPTION
Even for closed-source projects (like https://github.com/apify/store-website-content-crawler), the users imo deserve to know the release dates. This PR copies the `timestamp` from the branch with `release_link`.