### PR TITLE
chore: parametrize runner tag for build workflow

### DIFF
--- a/.github/workflows/build_docker_image_and_push_to_ecr.yaml
+++ b/.github/workflows/build_docker_image_and_push_to_ecr.yaml
@@ -54,6 +54,11 @@ on:
         description: Override the author of event
         required: false
         type: string
+      runner:
+        description: Runner to use
+        required: false
+        type: string
+        default: ubuntu-latest
 
     secrets:
       awsAccessKeyId:
@@ -81,7 +86,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Send notification to slack
         if: inputs.slackChannelId != ''

--- a/.github/workflows/build_docker_image_and_push_to_ecr.yaml
+++ b/.github/workflows/build_docker_image_and_push_to_ecr.yaml
@@ -58,7 +58,7 @@ on:
         description: Runner to use
         required: false
         type: string
-        default: ubuntu-latest
+        default: ubuntu-22.04
 
     secrets:
       awsAccessKeyId:


### PR DESCRIPTION
- Enable runs-on parameter configurable from inputs (to be able to select different runner from the "caller" workflow)