### PR TITLE
Poetry enforce specific Python version

### DIFF
--- a/.github/workflows/python_docs_check.yaml
+++ b/.github/workflows/python_docs_check.yaml
@@ -39,8 +39,6 @@ jobs:
       - name: Install Python dependencies
         run: |
           pipx install --python ${{ inputs.python_version }} poetry
-          poetry config virtualenvs.use-poetry-python true
-          poetry env use ${{ matrix.python-version }}
           make install-dev
 
       - name: Build API reference

--- a/.github/workflows/python_docs_check.yaml
+++ b/.github/workflows/python_docs_check.yaml
@@ -39,6 +39,8 @@ jobs:
       - name: Install Python dependencies
         run: |
           pipx install --python ${{ inputs.python_version }} poetry
+          poetry config virtualenvs.use-poetry-python true
+          poetry env use ${{ matrix.python-version }}
           make install-dev
 
       - name: Build API reference

--- a/.github/workflows/python_integration_tests.yaml
+++ b/.github/workflows/python_integration_tests.yaml
@@ -80,6 +80,8 @@ jobs:
       - name: Install Python dependencies
         run: |
           pipx install --python ${{ matrix.python-version }} poetry
+          poetry config virtualenvs.use-poetry-python true
+          poetry env use ${{ matrix.python-version }}
           make install-dev
 
       - name: Run integration tests

--- a/.github/workflows/python_integration_tests.yaml
+++ b/.github/workflows/python_integration_tests.yaml
@@ -80,6 +80,8 @@ jobs:
       - name: Install Python dependencies
         run: |
           pipx install --python ${{ matrix.python-version }} poetry
+          # This forces poetry to use specific Python version when installing a project.
+          # Raises error, if this Python version does not match project specific Python constraints. 
           poetry config virtualenvs.use-poetry-python true
           poetry env use ${{ matrix.python-version }}
           make install-dev

--- a/.github/workflows/python_lint_check.yaml
+++ b/.github/workflows/python_lint_check.yaml
@@ -23,6 +23,8 @@ jobs:
       - name: Install Python dependencies
         run: |
           pipx install --python ${{ matrix.python-version }} poetry
+          # This forces poetry to use specific Python version when installing a project.
+          # Raises error, if this Python version does not match project specific Python constraints. 
           poetry config virtualenvs.use-poetry-python true
           poetry env use ${{ matrix.python-version }}
           make install-dev

--- a/.github/workflows/python_lint_check.yaml
+++ b/.github/workflows/python_lint_check.yaml
@@ -23,6 +23,8 @@ jobs:
       - name: Install Python dependencies
         run: |
           pipx install --python ${{ matrix.python-version }} poetry
+          poetry config virtualenvs.use-poetry-python true
+          poetry env use ${{ matrix.python-version }}
           make install-dev
 
       - name: Run lint check

--- a/.github/workflows/python_type_check.yaml
+++ b/.github/workflows/python_type_check.yaml
@@ -23,6 +23,8 @@ jobs:
       - name: Install Python dependencies
         run: |
           pipx install --python ${{ matrix.python-version }} poetry
+          # This forces poetry to use specific Python version when installing a project.
+          # Raises error, if this Python version does not match project specific Python constraints. 
           poetry config virtualenvs.use-poetry-python true
           poetry env use ${{ matrix.python-version }}
           make install-dev

--- a/.github/workflows/python_type_check.yaml
+++ b/.github/workflows/python_type_check.yaml
@@ -24,6 +24,7 @@ jobs:
         run: |
           pipx install --python ${{ matrix.python-version }} poetry
           poetry config virtualenvs.use-poetry-python true
+          poetry env use ${{ matrix.python-version }}
           make install-dev
 
       - name: Run type check

--- a/.github/workflows/python_type_check.yaml
+++ b/.github/workflows/python_type_check.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pipx install --python ${{ matrix.python-version }} poetry
+          poetry config virtualenvs.use-poetry-python true
           make install-dev
 
       - name: Run type check

--- a/.github/workflows/python_unit_tests.yaml
+++ b/.github/workflows/python_unit_tests.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pipx install --python ${{ matrix.python-version }} poetry
+          poetry config virtualenvs.use-poetry-python true
           poetry env use ${{ matrix.python-version }}
           make install-dev
 

--- a/.github/workflows/python_unit_tests.yaml
+++ b/.github/workflows/python_unit_tests.yaml
@@ -36,7 +36,6 @@ jobs:
         run: |
           pipx install --python ${{ matrix.python-version }} poetry
           poetry config virtualenvs.use-poetry-python true
-          poetry env use ${{ matrix.python-version }}
           make install-dev
 
       - name: Run unit tests

--- a/.github/workflows/python_unit_tests.yaml
+++ b/.github/workflows/python_unit_tests.yaml
@@ -35,6 +35,8 @@ jobs:
       - name: Install Python dependencies
         run: |
           pipx install --python ${{ matrix.python-version }} poetry
+          # This forces poetry to use specific Python version when installing a project.
+          # Raises error, if this Python version does not match project specific Python constraints.
           poetry config virtualenvs.use-poetry-python true
           poetry env use ${{ matrix.python-version }}
           make install-dev

--- a/.github/workflows/python_unit_tests.yaml
+++ b/.github/workflows/python_unit_tests.yaml
@@ -36,6 +36,7 @@ jobs:
         run: |
           pipx install --python ${{ matrix.python-version }} poetry
           poetry config virtualenvs.use-poetry-python true
+          poetry env use ${{ matrix.python-version }}
           make install-dev
 
       - name: Run unit tests

--- a/.github/workflows/python_unit_tests.yaml
+++ b/.github/workflows/python_unit_tests.yaml
@@ -32,38 +32,10 @@ jobs:
         run: |
           pip install poetry
 
-      - name: Check Python version against project requirements
-        shell: python
-        run: |
-          import sys
-          from contextlib import suppress
-          from poetry.core.constraints.version import parse_constraint
-
-          try:
-            import tomllib
-          except ImportError:
-            import tomli as tomllib
-
-          config = tomllib.load(open('pyproject.toml', 'rb'))
-          constraints = []
-
-          with suppress(KeyError):
-            constraints.append(parse_constraint(config['tool']['poetry']['dependencies']['python']))
-          with suppress(KeyError):
-            constraints.append(parse_constraint(config['project']['requires-python']))
-
-          python_version = parse_constraint('${{ matrix.python-version }}')
-          if not all(con.allows(python_version) for con in constraints):
-            print(f'Python version {str(python_version)} is not allowed by project settings', file=sys.stderr)
-            sys.exit(1)
-
-      - name: Uninstall global poetry again
-        run: |
-          pip uninstall -y poetry
-
       - name: Install Python dependencies
         run: |
           pipx install --python ${{ matrix.python-version }} poetry
+          poetry env use ${{ matrix.python-version }}
           make install-dev
 
       - name: Run unit tests


### PR DESCRIPTION
Use poetry configuration to enforce specific Python version used instead of custom Python script.
Use in other related workflows.

Tested in CI. This is screenshot showing the difference when Python constraint were not met:
![image](https://github.com/user-attachments/assets/072fdbce-774d-462e-8393-5e26a2309566)


Poetry functionality described in:
https://python-poetry.org/docs/managing-environments/