### PR TITLE
chore: migrate from poetry to uv

### DIFF
--- a/.github/workflows/python_bump_and_update_changelog.yaml
+++ b/.github/workflows/python_bump_and_update_changelog.yaml
@@ -46,19 +46,12 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - name: Update package version in pyproject.toml
+        shell: bash
         run: |
-          uv pip install tomlkit &&
-          uv run python -c "
-          import tomlkit
-          with open('pyproject.toml', 'r+') as f:
-              data = tomlkit.parse(f.read())
-              target_version = '${{ inputs.version_number }}'
-              data['project']['version'] = target_version
-              print(f'Updating version in pyproject.toml to {target_version}')
-              f.seek(0)
-              f.write(tomlkit.dumps(data))
-              f.truncate()
-          "
+          new_version="${{ inputs.version_number }}"
+          echo "Updating version in pyproject.toml to ${new_version}"
+          # Update the "version" key in the [project] section of pyproject.toml.
+          sed -i '/^\[project\]/,/^\[/ s/^\(version\s*=\s*\)".*"/\1"'${new_version}'"/' pyproject.toml
 
       - name: Update CHANGELOG.md
         uses: DamianReeves/write-file-action@master

--- a/.github/workflows/python_bump_and_update_changelog.yaml
+++ b/.github/workflows/python_bump_and_update_changelog.yaml
@@ -46,7 +46,19 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - name: Update package version in pyproject.toml
-        run: uv version ${{ inputs.version_number }}
+        run: |
+          uv pip install tomlkit &&
+          uv run python -c "
+          import tomlkit
+          with open('pyproject.toml', 'r+') as f:
+              data = tomlkit.parse(f.read())
+              target_version = '${{ inputs.version_number }}'
+              data['project']['version'] = target_version
+              print(f'Updating version in pyproject.toml to {target_version}')
+              f.seek(0)
+              f.write(tomlkit.dumps(data))
+              f.truncate()
+          "
 
       - name: Update CHANGELOG.md
         uses: DamianReeves/write-file-action@master

--- a/.github/workflows/python_bump_and_update_changelog.yaml
+++ b/.github/workflows/python_bump_and_update_changelog.yaml
@@ -40,11 +40,13 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
-      - name: Install poetry
-        run: pipx install --python ${{ inputs.python_version }} poetry
+      - name: Set up uv package manager
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ inputs.python_version }}
 
       - name: Update package version in pyproject.toml
-        run: poetry version ${{ inputs.version_number }}
+        run: uv version ${{ inputs.version_number }}
 
       - name: Update CHANGELOG.md
         uses: DamianReeves/write-file-action@master

--- a/.github/workflows/python_docs_check.yaml
+++ b/.github/workflows/python_docs_check.yaml
@@ -36,10 +36,13 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
 
+      - name: Set up uv package manager
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ inputs.python_version }}
+
       - name: Install Python dependencies
-        run: |
-          pipx install --python ${{ inputs.python_version }} poetry
-          make install-dev
+        run: make install-dev
 
       - name: Build API reference
         run: make build-api-reference

--- a/.github/workflows/python_integration_tests.yaml
+++ b/.github/workflows/python_integration_tests.yaml
@@ -33,10 +33,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up uv package manager
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Install Python dependencies
-        run: |
-          pipx install --python ${{ matrix.python-version }} poetry
-          make install-dev
+        run: make install-dev
 
       - name: Run integration tests
         run: make INTEGRATION_TESTS_CONCURRENCY=8 integration-tests
@@ -77,14 +80,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Python dependencies
-        run: |
-          pipx install --python ${{ matrix.python-version }} poetry
-          # This forces poetry to use specific Python version when installing a project.
-          # Raises error, if this Python version does not match project specific Python constraints. 
-          poetry config virtualenvs.use-poetry-python true
-          poetry env use ${{ matrix.python-version }}
-          make install-dev
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv package manager
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Run integration tests
         run: make INTEGRATION_TESTS_CONCURRENCY=8 integration-tests

--- a/.github/workflows/python_lint_check.yaml
+++ b/.github/workflows/python_lint_check.yaml
@@ -20,14 +20,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up uv package manager
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Install Python dependencies
-        run: |
-          pipx install --python ${{ matrix.python-version }} poetry
-          # This forces poetry to use specific Python version when installing a project.
-          # Raises error, if this Python version does not match project specific Python constraints. 
-          poetry config virtualenvs.use-poetry-python true
-          poetry env use ${{ matrix.python-version }}
-          make install-dev
+        run: make install-dev
 
       - name: Run lint check
         run: make lint

--- a/.github/workflows/python_type_check.yaml
+++ b/.github/workflows/python_type_check.yaml
@@ -20,14 +20,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up uv package manager
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Install Python dependencies
-        run: |
-          pipx install --python ${{ matrix.python-version }} poetry
-          # This forces poetry to use specific Python version when installing a project.
-          # Raises error, if this Python version does not match project specific Python constraints. 
-          poetry config virtualenvs.use-poetry-python true
-          poetry env use ${{ matrix.python-version }}
-          make install-dev
+        run: make install-dev
 
       - name: Run type check
         run: make type-check

--- a/.github/workflows/python_unit_tests.yaml
+++ b/.github/workflows/python_unit_tests.yaml
@@ -28,18 +28,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Poetry for version checking
-        run: |
-          pip install poetry
+      - name: Set up uv package manager
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Python dependencies
-        run: |
-          pipx install --python ${{ matrix.python-version }} poetry
-          # This forces poetry to use specific Python version when installing a project.
-          # Raises error, if this Python version does not match project specific Python constraints.
-          poetry config virtualenvs.use-poetry-python true
-          poetry env use ${{ matrix.python-version }}
-          make install-dev
+        run: make install-dev
 
       - name: Run unit tests
         run: make unit-tests

--- a/prepare-pypi-distribution/action.yaml
+++ b/prepare-pypi-distribution/action.yaml
@@ -58,7 +58,10 @@ runs:
               .[0] + 1
             '
           )
-          uv version "${{ inputs.version_number }}b$next_beta"
+          new_version="${{ inputs.version_number }}b${next_beta}"
+          echo "Updating version in pyproject.toml to ${new_version}"
+          # Update the "version" key in the [project] section of pyproject.toml.
+          sed -i '/^\[project\]/,/^\[/ s/^\(version\s*=\s*\)".*"/\1"'${new_version}'"/' pyproject.toml
         fi
 
     # Builds the package.

--- a/prepare-pypi-distribution/action.yaml
+++ b/prepare-pypi-distribution/action.yaml
@@ -29,11 +29,14 @@ runs:
       with:
         python-version: ${{ inputs.python_version }}
 
+    - name: Set up uv package manager
+      uses: astral-sh/setup-uv@v5
+      with:
+        python-version: ${{ inputs.python_version }}
+
     - name: Install dependencies
       shell: bash
-      run: |
-        pipx install --python ${{ inputs.python_version }} poetry
-        make install-dev
+      run: make install-dev
 
     # Updates the version number in the project's configuration.
     - name: Set version in pyproject.toml
@@ -55,7 +58,7 @@ runs:
               .[0] + 1
             '
           )
-          poetry version "${{ inputs.version_number }}b$next_beta"
+          uv version "${{ inputs.version_number }}b$next_beta"
         fi
 
     # Builds the package.


### PR DESCRIPTION
- Migrate from `poetry` to `uv`.
- Relates: https://github.com/apify/crawlee-python/issues/628
- PRs to crawlee/SDK/client will follow.