### PR TITLE
chore: add grafana annotation workflow

### DIFF
--- a/.github/workflows/grafana_annotation.yaml
+++ b/.github/workflows/grafana_annotation.yaml
@@ -1,0 +1,47 @@
+name: grafana annotation
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: Environment
+        required: false
+        type: string
+      grafanaAnnotationTags:
+        description: Custom annotation tags
+        required: false
+        type: string
+      grafanaAnnotationText:
+        description: Custom annotation text
+        required: true
+        type: string
+      grafanaAnnotationId:
+        description: Annotation Id
+        required: false
+        type: string
+
+    secrets:
+      grafanaApiToken:
+        description: Grafana API token
+        required: true
+
+    outputs:
+      annotation_id:
+        description: Annotation Id
+        value: ${{ jobs.grafana.outputs.annotation_id }}   
+
+jobs:
+  grafana:
+    runs-on: ubuntu-latest
+    outputs:
+      annotation_id: ${{ steps.grafana.outputs.annotation-id }}
+    steps:
+      - name: add Grafana annotation
+        id: grafana
+        uses: hexionas/grafana-annotation-action@v1.0.1
+        with:
+          grafanaHost: "https://grafana.apify.dev"
+          grafanaToken: ${{ secrets.grafanaApiToken }}
+          grafanaText: ${{ inputs.grafanaAnnotationText }}
+          grafanaTags: ${{ inputs.grafanaAnnotationTags }}
+          grafanaAnnotationID: ${{ inputs.grafanaAnnotationId }}


### PR DESCRIPTION
Usage:

```
name: Grafana annotation
on:
  workflow_call:

jobs:  
  grafana-annotation-start:
    uses: apify/workflows/.github/workflows/grafana_annotation.yaml@main
    with:
      grafanaAnnotationTags: |
        foo:bar
        environment: ${{ inputs.environment }}
      grafanaAnnotationText: |
        mandatory text
    secrets:
      grafanaApiToken: ${{ secrets.GRAFANAAPITOKEN }}

  dosomething:
    runs-on: ubuntu-latest
    needs: grafana-annotation-start
    steps:
      - name: Action that takes some time
        run: sleep 30

  grafana-annotation-stop:
    uses: apify/workflows/.github/workflows/grafana_annotation.yaml@main
    with:
      grafanaAnnotationText: |
        mandatory text
      grafanaAnnotationID: ${{ needs.grafana-annotation-start.outputs.annotation_id }}
    secrets:
      grafanaApiToken: ${{ secrets.GRAFANAAPITOKEN }}
```