### PR TITLE
feat: update actionlint

### DIFF
--- a/.github/workflows/lint_gh_actions.yaml
+++ b/.github/workflows/lint_gh_actions.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   # renovate: datasource=docker depName=rhysd/actionlint
-  ACTIONLINT_VERSION: 1.7.0
+  ACTIONLINT_VERSION: 1.7.7
 
 jobs:
   lint:


### PR DESCRIPTION
This PR updates actionlint to fix some incorrectly reported problems (e.g. `ubuntu-22.04-arm` not being accepted as a valid runner)