### PR TITLE
chore: Add `python-version` as parameter for python workflows

### DIFF
--- a/.github/workflows/python_lint_check.yaml
+++ b/.github/workflows/python_lint_check.yaml
@@ -2,6 +2,12 @@ name: Lint check
 
 on:
   workflow_call:
+    inputs:
+      python-version:
+        description: 'List of Python versions to be used'
+        default: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
+        required: false
+        type: string
 
 jobs:
   lint_check:
@@ -9,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"] # All supported Python versions.
+        python-version: ${{ fromJSON(inputs.python-version)}}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/python_lint_check.yaml
+++ b/.github/workflows/python_lint_check.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       python-version:
-        description: 'List of Python versions to be used'
+        description: List of Python versions to be used
         default: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
         required: false
         type: string

--- a/.github/workflows/python_type_check.yaml
+++ b/.github/workflows/python_type_check.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       python-version:
-        description: 'List of Python versions to be used'
+        description: List of Python versions to be used
         default: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
         required: false
         type: string

--- a/.github/workflows/python_type_check.yaml
+++ b/.github/workflows/python_type_check.yaml
@@ -2,6 +2,12 @@ name: Type check
 
 on:
   workflow_call:
+    inputs:
+      python-version:
+        description: 'List of Python versions to be used'
+        default: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
+        required: false
+        type: string
 
 jobs:
   type_check:
@@ -9,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"] # All supported Python versions.
+        python-version: ${{ fromJSON(inputs.python-version)}}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/python_unit_tests.yaml
+++ b/.github/workflows/python_unit_tests.yaml
@@ -8,7 +8,7 @@ on:
         description: Used to set the HTTPBIN_URL environment variable
     inputs:
       python-version:
-        description: 'List of Python versions to be used'
+        description: List of Python versions to be used
         default: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
         required: false
         type: string

--- a/.github/workflows/python_unit_tests.yaml
+++ b/.github/workflows/python_unit_tests.yaml
@@ -6,6 +6,12 @@ on:
       httpbin_url:
         required: false
         description: Used to set the HTTPBIN_URL environment variable
+    inputs:
+      python-version:
+        description: 'List of Python versions to be used'
+        default: '["3.9", "3.10", "3.11", "3.12", "3.13"]'
+        required: false
+        type: string
 
 jobs:
   unit_tests:
@@ -14,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"] # All supported Python versions.
+        python-version: ${{ fromJSON(inputs.python-version)}}
     runs-on: ${{ matrix.os }}
     env:
       HTTPBIN_URL: ${{ secrets.httpbin_url || 'https://httpbin.org' }}


### PR DESCRIPTION
Add `python-version` as parameter to check, lint and test workflows.
When no input is passed, then the behavior is the same as before the change.
