### PR TITLE
fix: Always do at least a patch bump in git-cliff-release

### DIFF
--- a/git-cliff-release/action.yaml
+++ b/git-cliff-release/action.yaml
@@ -89,7 +89,7 @@ runs:
           version_number=$(git-cliff --bumped-version | sed s/^v//)
 
           # If there are no commits that increase semver, do a patch bump
-          if [[ "$(git describe --tags --abbrev=0)" = "v${ version_number }" ]]; then
+          if [[ "$(git describe --tags --abbrev=0)" = "v${version_number}" ]]; then
             version_number=$(git-cliff --bump patch --context | jq -r '.[0].version' | sed s/^v//)
           fi
         else

--- a/git-cliff-release/action.yaml
+++ b/git-cliff-release/action.yaml
@@ -85,13 +85,17 @@ runs:
         set -x
         if [[ '${{ inputs.release_type }}' = custom ]]; then
           version_number=$(echo ${{ inputs.custom_version }} | sed s/^v//)
-        elif [[ '${{ inputs.release_type }}' = auto || '${{ inputs.release_type }}' = prerelease ]]; then
+        elif [[ '${{ inputs.release_type }}' = auto ]]; then
           version_number=$(git-cliff --bumped-version | sed s/^v//)
 
-          # If there are no commits that increase semver, do a patch bump
+          # If there are no commits that increase semver, break
           if [[ "$(git describe --tags --abbrev=0)" = "v${version_number}" ]]; then
-            version_number=$(git-cliff --bump patch --context | jq -r '.[0].version' | sed s/^v//)
+            echo "::error title=Nothing to release::There were no commits that trigger a version bump since the last release"
+            exit 1
           fi
+        elif [[ '${{ inputs.release_type }}' = prerelease ]]; then
+          # Prereleases only ever increase the patch version
+          version_number=$(git-cliff --bump patch --context | jq -r '.[0].version' | sed s/^v//)
         else
           version_number=$(git-cliff --bump '${{ inputs.release_type }}' --context | jq -r '.[0].version' | sed s/^v//)
         fi

--- a/git-cliff-release/action.yaml
+++ b/git-cliff-release/action.yaml
@@ -87,6 +87,11 @@ runs:
           version_number=$(echo ${{ inputs.custom_version }} | sed s/^v//)
         elif [[ '${{ inputs.release_type }}' = auto || '${{ inputs.release_type }}' = prerelease ]]; then
           version_number=$(git-cliff --bumped-version | sed s/^v//)
+
+          # If there are no commits that increase semver, do a patch bump
+          if [[ "$(git describe --tags --abbrev=0)" = "v${ version_number }" ]]; then
+            version_number=$(git-cliff --bump patch --context | jq -r '.[0].version' | sed s/^v//)
+          fi
         else
           version_number=$(git-cliff --bump '${{ inputs.release_type }}' --context | jq -r '.[0].version' | sed s/^v//)
         fi

--- a/git-cliff-release/cliff.toml
+++ b/git-cliff-release/cliff.toml
@@ -74,7 +74,7 @@ split_commits = false
 commit_preprocessors = []
 # regex for parsing and grouping commits
 commit_parsers = [
-  { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+  { message = "^feat|^patch", group = "<!-- 0 -->🚀 Features" },
   { message = "^fix|^bug", group = "<!-- 1 -->🐛 Bug Fixes" },
   # { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
   { message = "^doc", skip = true },


### PR DESCRIPTION
This should take care of the likes of https://github.com/apify/apify-client-js/actions/runs/14640306894/job/41080921820

- closes #148 