### PR TITLE
fix: Fix pre-release version bump

### DIFF
--- a/git-cliff-release/action.yaml
+++ b/git-cliff-release/action.yaml
@@ -95,9 +95,9 @@ runs:
           fi
         elif [[ '${{ inputs.release_type }}' = prerelease ]]; then
           # Prereleases only ever increase the patch version
-          version_number=$(git-cliff --bump patch --context | jq -r '.[0].version' | sed s/^v//)
+          version_number=$(git-cliff --bump patch --unreleased --context | jq -r '.[0].version' | sed s/^v//)
         else
-          version_number=$(git-cliff --bump '${{ inputs.release_type }}' --context | jq -r '.[0].version' | sed s/^v//)
+          version_number=$(git-cliff --bump '${{ inputs.release_type }}' --unreleased --context | jq -r '.[0].version' | sed s/^v//)
         fi
         echo version_number=$version_number | tee -a $GITHUB_OUTPUT
         echo tag_name=v$version_number | tee -a $GITHUB_OUTPUT

--- a/git-cliff-release/cliff.toml
+++ b/git-cliff-release/cliff.toml
@@ -6,6 +6,8 @@
 # See documentation for more information on available options.
 
 [changelog]
+# changelog body will be rendered even if there are no releases to process - required for pre-release version bumps
+render_always = true
 # changelog header
 header = """
 # Changelog\n


### PR DESCRIPTION
- Looks like the fixes from https://github.com/apify/workflows/pull/188 were not enough
- https://github.com/apify/apify-client-js/actions/runs/15299379719/job/43035925424 still failed
- According to https://github.com/orhun/git-cliff/issues/816 and tests conducted by yours truly, the proposed changes should fix this for good (ha)

