### PR TITLE
chore: Add optional `os` parameter to Python unit test workflow

### DIFF
--- a/.github/workflows/python_unit_tests.yaml
+++ b/.github/workflows/python_unit_tests.yaml
@@ -11,6 +11,11 @@ on:
         description: List of Python versions to be used
         required: true
         type: string
+      os:
+        description: List of operating systems to be used
+        default: '["ubuntu-latest", "windows-latest"]'
+        required: false
+        type: string
 
 jobs:
   unit_tests:
@@ -18,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ${{ fromJSON(inputs.os)}}
         python-version: ${{ fromJSON(inputs.python-versions)}}
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
- To enable using `macOS` in selected repos.