### PR TITLE
feat: Update `actionlint` to support schedule timezones

### DIFF
--- a/.github/workflows/lint_gh_actions.yaml
+++ b/.github/workflows/lint_gh_actions.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   # renovate: datasource=docker depName=rhysd/actionlint
-  ACTIONLINT_VERSION: 1.7.7
+  ACTIONLINT_VERSION: 1.7.12
 
 jobs:
   lint:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,11 +6,6 @@ on:
       # TODO: All these inputs are not entirely necessary, they are just there for convenience of "setup Node.js" step,
       #       where they are required. Making them optional requires additional logic, that might be un-necessary for our purposes
       #       Best would be if "actions/setup-node" would be able to parse these from .npmrc and .nvmrc (except token of course)
-      npmAuth:
-        description: Whether to authenticate to NPM registry
-        required: false
-        type: boolean
-        default: true
       nodeVersionFile:
         description: Path to node version file
         required: false
@@ -121,7 +116,6 @@ jobs:
       - name: setup Node.js
         uses: actions/setup-node@v6
         with:
-          always-auth: ${{ inputs.npmAuth }}
           node-version-file: ${{ inputs.nodeVersionFile }}
           registry-url: ${{ inputs.npmRegistryUrl }}
           scope: ${{ inputs.npmScope }}


### PR DESCRIPTION
GitHub now supports specifying the timezone in scheduled workflows. This updates Actionlint to a new version which supports that syntax.

I'm adding support for the timezones to `apify-core` in https://github.com/apify/apify-core/pull/26574.

I've also had to fix lint by removing an outdated input to `setup-node` in the `tests` workflow. I've checked our codebase and it's not used anywhere in calling workflows.