### PR TITLE
feat(pnpm-install): add working-directory input

### DIFF
--- a/pnpm-install/action.yaml
+++ b/pnpm-install/action.yaml
@@ -1,6 +1,12 @@
 name: "pnpm install"
 description: "Run pnpm install with cache enabled"
 
+inputs:
+  working-directory:
+    description: "Directory containing pnpm-lock.yaml (defaults to repo root)"
+    required: false
+    default: "."
+
 runs:
   using: "composite"
   steps:
@@ -37,6 +43,7 @@ runs:
 
     - name: Install dependencies
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: |
         pnpm install --frozen-lockfile --prefer-offline --loglevel error
       env:


### PR DESCRIPTION
## Summary
- Adds optional `working-directory` input (defaults to `.`) to the pnpm-install composite action
- Allows repos where the pnpm project is in a subdirectory (e.g. `impit/impit-node`) to use the shared action instead of inlining `pnpm/action-setup` + manual install

Backwards-compatible — defaults to repo root, no change for existing callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)