### PR TITLE
fix(pnpm-install): pass working-directory to package_json_file

### DIFF
--- a/pnpm-install/action.yaml
+++ b/pnpm-install/action.yaml
@@ -20,6 +20,7 @@ runs:
       name: Install pnpm
       with:
         run_install: false
+        package_json_file: ${{ inputs.working-directory }}/package.json
 
     - name: Expose pnpm config(s) through "$GITHUB_OUTPUT"
       id: pnpm-config


### PR DESCRIPTION
Follow-up to #269 — pnpm/action-setup reads the version from `package.json`. When working-directory is set (e.g. `impit-node`), root has no `package.json` and version lookup fails. Forward `working-directory` to `package_json_file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)