### PR TITLE
ci: rebase before pushing the changelog/version bump commit

### DIFF
--- a/.github/workflows/python_bump_and_update_changelog.yaml
+++ b/.github/workflows/python_bump_and_update_changelog.yaml
@@ -66,3 +66,4 @@ jobs:
           author_name: github-actions[bot]
           author_email: 41898282+github-actions[bot]@users.noreply.github.com
           message: "chore(release): Update changelog and package version [skip ci]"
+          pull: '--rebase --autostash'


### PR DESCRIPTION
## Summary
Add `pull: '--rebase --autostash'` to the `EndBug/add-and-commit` step in `python_bump_and_update_changelog.yaml` so the push survives a concurrent ref update on the default branch.

## Context
This is the same race that bit `apify/apify-client-js` in [run 25114327598](https://github.com/apify/apify-client-js/actions/runs/25114327598/job/73597522121):

```
remote rejected (cannot lock ref 'refs/heads/master': is at <new> but expected <old>)
```

The bypass actually succeeds (`remote: Bypassed rule violations for refs/heads/master`); the push is just non-fast-forward because something landed on the default branch between checkout and push.

This reusable workflow is consumed by `manual_release_stable.yaml` and `on_master.yaml` in:
- apify/apify-client-python
- apify/apify-sdk-python
- apify/crawlee-python

so this single change covers the changelog-commit race across all three Python repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)