### PR TITLE
ci: rebase before pushing the changelog/version commit

### DIFF
--- a/.github/workflows/python_bump_and_update_changelog.yaml
+++ b/.github/workflows/python_bump_and_update_changelog.yaml
@@ -61,8 +61,9 @@ jobs:
 
       - name: Commit changes
         id: commit
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           author_name: github-actions[bot]
           author_email: 41898282+github-actions[bot]@users.noreply.github.com
           message: "chore(release): Update changelog and package version [skip ci]"
+          pull: "--rebase --autostash"


### PR DESCRIPTION
## Summary

Add `pull: "--rebase --autostash"` to the `EndBug/add-and-commit` step in `python_bump_and_update_changelog.yaml` so the commit survives a concurrent ref update on `master`. Bumps `EndBug/add-and-commit` from `@v9` to `@v10` for consistency with the sibling docs workflows in `apify-{client,sdk}-python` and `crawlee-python`.

## Context

Same race condition that was fixed for the docs-theme commit in apify/apify-sdk-python#883 and apify/apify-client-js (run 25114327598):

```
remote rejected (cannot lock ref 'refs/heads/master': is at <new> but expected <old>)
```

It is non-fast-forward, not a permissions issue — something lands on `master` between checkout and push. This reusable workflow is called from `on_master.yaml` and `manual_release_stable.yaml` in `apify-client-python`, `apify-sdk-python`, and `crawlee-python` on every release, so it is exposed to the same race.

The sibling `manual_version_docs.yaml` and `manual_release_docs.yaml` callers in those three repos already use `pull: "--rebase --autostash"`; this aligns the changelog step.