### PR TITLE
chore: bump EndBug/add-and-commit from v9 to v10

### DIFF
--- a/.github/workflows/check-execute-workflow-dist.yaml
+++ b/.github/workflows/check-execute-workflow-dist.yaml
@@ -36,7 +36,7 @@ jobs:
         run: npm run build
 
       - name: Commit and push if changed
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           author_name: github-actions[bot]
           author_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/python_bump_and_update_changelog.yaml
+++ b/.github/workflows/python_bump_and_update_changelog.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Commit changes
         id: commit
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           author_name: github-actions[bot]
           author_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/git-cliff-release/README.md
+++ b/git-cliff-release/README.md
@@ -48,7 +48,7 @@ jobs:
           write-mode: overwrite
           contents: ${{ steps.metadata.outputs.changelog }}
       - name: Commit changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           author_name: Foo
           author_email: foo@bar.com
@@ -95,7 +95,7 @@ jobs:
           contents: ${{ steps.metadata.outputs.changelog }}
       - name: Commit changes
         id: commit
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           author_name: Foo
           author_email: foo@bar.com


### PR DESCRIPTION
## Summary

Bumps `EndBug/add-and-commit` from `v9` to `v10` in:

- `.github/workflows/check-execute-workflow-dist.yaml`
- `.github/workflows/python_bump_and_update_changelog.yaml`
- `git-cliff-release/README.md` (example snippets)

Keeps the action up to date with the latest major release.