### PR TITLE
fix(pnpm-install): skip swap setup on ARM64 runners

### DIFF
--- a/pnpm-install/action.yaml
+++ b/pnpm-install/action.yaml
@@ -10,8 +10,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Skip on ARM64: pierotofy/set-swap-space@v1.0 unconditionally calls
+    # `swapoff $(swapon --show=NAME | tail -n 1)`, which on ARM64 GitHub
+    # runners (no pre-allocated swap) resolves to `swapoff <empty>` and
+    # exits non-zero with "swapoff: bad usage". x86_64 runners ship with
+    # an existing swap file, so the action works there.
     - name: Set up swap space
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && runner.arch != 'ARM64'
       uses: pierotofy/set-swap-space@v1.0
       with:
         swap-size-gb: 10


### PR DESCRIPTION
## Summary

`pnpm-install/action.yaml` calls `pierotofy/set-swap-space@v1.0` unconditionally on Linux. That action runs:

```bash
SWAP_FILE=$(swapon --show=NAME | tail -n 1)
sudo swapoff $SWAP_FILE
```

On ARM64 GitHub runners (`ubuntu-22.04-arm64`, `ubuntu-22.04-N-core-arm64`, etc.) there's no pre-allocated swap, so `swapon --show` is empty, `SWAP_FILE` is empty, and `swapoff` exits with `bad usage` (exit code 16). Every job that uses this composite action then fails before pnpm install runs.

## Repro

Pretty much any workflow on an ARM64 runner that does `uses: apify/workflows/pnpm-install@main`. Hit this while migrating apify/apify-core to pnpm — its entire CI suite uses ARM64 boxes, so every job in the migration PR was red on the same swap step.

Failure log on ARM64:
```
swapoff: bad usage
Try 'swapoff --help' for more information.
##[error]Process completed with exit code 16.
```

## Change

Skip the swap step when `runner.arch == 'ARM64'`. x86_64 runners ship with an existing swap file so the action keeps working there. ARM64 runners typically have plenty of memory (apify-core CI uses 30 GB ARM64 boxes); not adding 10 GB of swap is fine.