### PR TITLE
feat(pnpm-install): optional github-registry-token input

### DIFF
--- a/pnpm-install/README.md
+++ b/pnpm-install/README.md
@@ -9,3 +9,23 @@ steps:
   - name: Install pnpm and dependencies
     uses: apify/workflows/pnpm-install@main
 ```
+
+### Inputs
+
+- `working-directory` (optional, default `.`) — Directory containing `pnpm-lock.yaml`.
+- `github-registry-token` (optional) — When set, configures `//npm.pkg.github.com/:_authToken=<token>` in `~/.npmrc` before installing, so private `@<scope>/*` packages published to the GitHub npm registry can be resolved. Pass a token with read access to those packages.
+
+### Example: install with GitHub registry auth
+
+```yaml
+steps:
+  - name: setup Node.js
+    uses: actions/setup-node@v6
+    with:
+      node-version-file: '.nvmrc'
+
+  - name: Install pnpm and dependencies
+    uses: apify/workflows/pnpm-install@main
+    with:
+      github-registry-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_REGISTRY_TOKEN }}
+```

--- a/pnpm-install/action.yaml
+++ b/pnpm-install/action.yaml
@@ -6,6 +6,17 @@ inputs:
     description: "Directory containing pnpm-lock.yaml (defaults to repo root)"
     required: false
     default: "."
+  github-registry-token:
+    description: |
+      Optional auth token for the GitHub npm registry (npm.pkg.github.com).
+      When set, configures `//npm.pkg.github.com/:_authToken=<token>` in the
+      user-global ~/.npmrc before installing, so private @<scope>/* packages
+      published to the GitHub registry resolve. Caller should pass a token
+      with read access to the relevant packages (e.g. a service account PAT
+      via `${{ secrets.GH_REGISTRY_TOKEN }}`). Leave unset for repos that
+      install only from the public npm registry.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -26,6 +37,18 @@ runs:
       with:
         run_install: false
         package_json_file: ${{ inputs.working-directory }}/package.json
+
+    # `npm` is always available on the runner via setup-node; using it here
+    # avoids ordering issues (corepack-managed pnpm isn't on PATH at every
+    # step) and writes the token into the user-global ~/.npmrc that pnpm
+    # also reads during install.
+    - name: Configure GitHub npm registry auth
+      if: inputs.github-registry-token != ''
+      shell: bash
+      env:
+        GITHUB_REGISTRY_TOKEN: ${{ inputs.github-registry-token }}
+      run: |
+        npm config set "//npm.pkg.github.com/:_authToken=${GITHUB_REGISTRY_TOKEN}"
 
     - name: Expose pnpm config(s) through "$GITHUB_OUTPUT"
       id: pnpm-config


### PR DESCRIPTION
## Summary

Adds an optional `github-registry-token` input to the `pnpm-install` composite action. When set, it writes `//npm.pkg.github.com/:_authToken=<token>` to `~/.npmrc` before installing, so consumers depending on private `@<scope>/*` packages on the GitHub npm registry can collapse `setup-node` + manual auth + install into a single composite call.

Before:

```yaml
- uses: actions/setup-node@v6
  with:
    node-version-file: '.nvmrc'
- name: Set up GitHub package registry authentication
  run: npm config set "//npm.pkg.github.com/:_authToken=${APIFY_SERVICE_ACCOUNT_GITHUB_REGISTRY_TOKEN}"
- uses: apify/workflows/pnpm-install@main
  env:
    APIFY_SERVICE_ACCOUNT_GITHUB_REGISTRY_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_REGISTRY_TOKEN }}
```

After:

```yaml
- uses: actions/setup-node@v6
  with:
    node-version-file: '.nvmrc'
- uses: apify/workflows/pnpm-install@main
  with:
    github-registry-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_REGISTRY_TOKEN }}
```

## Why npm config set, not pnpm config set

`npm` ships with the runner's Node from `setup-node` and is always on PATH. Corepack-managed `pnpm` only lands on PATH after `pnpm/action-setup` runs — putting the auth step before that would break. Both write to the same user-global `~/.npmrc` that `pnpm install` reads.

## Compatibility

Default is empty, so every existing caller is unaffected until they opt in. Once a repo passes the token through this input, it can drop its standalone `npm config set` step.

## Motivation

Came up while migrating apify-core to pnpm — every workflow currently duplicates the same auth boilerplate. Folding it into the composite action removes the duplication and makes the action universally usable from repos with private GitHub-registry deps.