### PR TITLE
fix(pnpm-install): drop ${{ }} expression from description

### DIFF
--- a/pnpm-install/action.yaml
+++ b/pnpm-install/action.yaml
@@ -7,14 +7,14 @@ inputs:
     required: false
     default: "."
   github-registry-token:
-    description: |
+    description: >-
       Optional auth token for the GitHub npm registry (npm.pkg.github.com).
-      When set, configures `//npm.pkg.github.com/:_authToken=<token>` in the
+      When set, configures //npm.pkg.github.com/:_authToken=<token> in the
       user-global ~/.npmrc before installing, so private @<scope>/* packages
       published to the GitHub registry resolve. Caller should pass a token
-      with read access to the relevant packages (e.g. a service account PAT
-      via `${{ secrets.GH_REGISTRY_TOKEN }}`). Leave unset for repos that
-      install only from the public npm registry.
+      with read access to the relevant packages (e.g. a service-account PAT
+      from a repo secret). Leave unset for repos that install only from the
+      public npm registry.
     required: false
     default: ""
 


### PR DESCRIPTION
## Summary

Hotfix for #277. The merged action.yaml has a literal `${{ secrets.GH_REGISTRY_TOKEN }}` inside the `inputs.github-registry-token.description` field as an example. GitHub Actions evaluates that expression even though it sits inside a description string — and the `secrets` context is rejected inside a composite action file:

```
##[error]apify/workflows/main/pnpm-install/action.yaml (Line: 10, Col: 18):
Unrecognized named-value: 'secrets'. Located at position 1 within expression:
secrets.GH_REGISTRY_TOKEN
```

That breaks every consumer that picks up `@main` (apify-core's CI is fully red right now).

Reword the description without an example expression, and switch to a folded scalar (`>-`) so we don't accidentally re-introduce a `${{ }}` token.

## Verification

apify-core CI on the PR consuming `@main` will turn green again as soon as this lands.