### PR TITLE
fix(pnpm-install): keep github-registry-token off disk

### DIFF
--- a/pnpm-install/action.yaml
+++ b/pnpm-install/action.yaml
@@ -38,17 +38,22 @@ runs:
         run_install: false
         package_json_file: ${{ inputs.working-directory }}/package.json
 
-    # `npm` is always available on the runner via setup-node; using it here
-    # avoids ordering issues (corepack-managed pnpm isn't on PATH at every
-    # step) and writes the token into the user-global ~/.npmrc that pnpm
-    # also reads during install.
+    # Write a *template* (the literal string `${GITHUB_REGISTRY_TOKEN}`) into
+    # ~/.npmrc, NOT the expanded token. Using single quotes here is load-
+    # bearing — they prevent the shell from expanding the variable, so the
+    # actual token never lands on disk. pnpm/npm expand the template at
+    # registry-fetch time, reading the env var that we inject only for the
+    # install step below. Once that step finishes the env var is gone and
+    # ~/.npmrc holds an unusable template, so later steps in the same job
+    # cannot exfiltrate the token.
+    #
+    # `npm` is always available on the runner via setup-node and is used
+    # here only because corepack-managed pnpm isn't on PATH at every step.
     - name: Configure GitHub npm registry auth
       if: inputs.github-registry-token != ''
       shell: bash
-      env:
-        GITHUB_REGISTRY_TOKEN: ${{ inputs.github-registry-token }}
       run: |
-        npm config set "//npm.pkg.github.com/:_authToken=${GITHUB_REGISTRY_TOKEN}"
+        npm config set '//npm.pkg.github.com/:_authToken=${GITHUB_REGISTRY_TOKEN}'
 
     - name: Expose pnpm config(s) through "$GITHUB_OUTPUT"
       id: pnpm-config
@@ -70,6 +75,9 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pnpm-store-cache-${{ steps.cache-rotation.outputs.YEAR_MONTH }}-
 
+    # GITHUB_REGISTRY_TOKEN is exposed only for this step. The .npmrc
+    # template written above expands it at registry-fetch time, then it's
+    # gone — no plaintext token ends up on disk for later steps to read.
     - name: Install dependencies
       shell: bash
       working-directory: ${{ inputs.working-directory }}
@@ -77,3 +85,4 @@ runs:
         pnpm install --frozen-lockfile --prefer-offline --loglevel error
       env:
         HUSKY: "0"
+        GITHUB_REGISTRY_TOKEN: ${{ inputs.github-registry-token }}


### PR DESCRIPTION
## Summary

Reported by František on the [apify-core pnpm migration review](https://github.com/apify/apify-core/pull/27608): the current `github-registry-token` flow writes the *expanded* token into `~/.npmrc`, where any later step in the same job can read it. That's a regression vs the npm pattern this action replaced.

The npm pattern was two-step:
1. `npm config set '//npm.pkg.github.com/:_authToken=${APIFY_..._TOKEN}'` — single quotes, the *template* (literal `${VAR}`) lands in `~/.npmrc`, not the actual value.
2. `npm install` ran with `env: APIFY_..._TOKEN: ${{ secrets... }}` — npm expanded the template at fetch time using the env var, which only existed for that one step.

The token never touched disk, and was unreachable to any later step. This PR restores that behaviour for the composite:

- Auth step writes the literal template `'\${GITHUB_REGISTRY_TOKEN}'` (single quotes — load-bearing) into `~/.npmrc`.
- The install step is the only one that sets `GITHUB_REGISTRY_TOKEN` in `env:`. pnpm expands the template at registry-fetch time, then the env var is gone.
- After the install step, `~/.npmrc` contains `…_authToken=\${GITHUB_REGISTRY_TOKEN}` — an unusable template. Anything compromised in a later step cannot read the token.

## Compatibility

No input/output changes. Callers don't need to update anything.

## Verification

- apify-core#27608 already consumes `@main` and runs successfully against this token; once this lands the only behaviour change is the contents of `~/.npmrc` (template instead of expanded value).