### PR TITLE
fix: Update `getsentry/action-release` to fix handling of 504 errors

### DIFF
--- a/.github/workflows/release_marker.yaml
+++ b/.github/workflows/release_marker.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: mark deploy - frontend
         if: inputs.sentryEnvironmentFrontend != ''
-        uses: getsentry/action-release@v1
+        uses: getsentry/action-release@v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.sentryAuthToken }}
           SENTRY_ORG: ${{ inputs.sentryOrg }}
@@ -85,7 +85,7 @@ jobs:
 
       - name: mark deploy - backend
         if: inputs.sentryEnvironmentBackend != ''
-        uses: getsentry/action-release@v1
+        uses: getsentry/action-release@v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.sentryAuthToken }}
           SENTRY_ORG: ${{ inputs.sentryOrg }}


### PR DESCRIPTION
Our release workflows often fail on "504 Gateway timeout" errors when marking the releases in Sentry.

The marking happens through the `getsentry/action-release` GitHub Action. Sentry has released an [updated version](https://github.com/getsentry/action-release/releases/tag/v3.5.0) to this action which adds retries on 5xx errors. I'm updating to that version in order to unblock the workflows.