### PR TITLE
fix(pnpm-install): pin lock-hash to step output so cache-save survives teardown

### DIFF
--- a/pnpm-install/action.yaml
+++ b/pnpm-install/action.yaml
@@ -67,11 +67,23 @@ runs:
       run: |
         echo "YEAR_MONTH=$(/bin/date -u "+%Y%m")" >> $GITHUB_OUTPUT
 
+    # Pre-compute the lockfile hash and store it as a step output. `actions/cache@v4`
+    # re-evaluates `key:` in its post-step (cache-save) at job teardown, and on some
+    # self-hosted/k8s runners the workspace is wiped before that runs — calling
+    # `hashFiles('**/pnpm-lock.yaml')` from the post-step then fails the job after
+    # all real steps have already passed. Capturing the hash once here pins the
+    # value to a step output, which survives teardown.
+    - name: Compute pnpm-lock.yaml hash
+      id: pnpm-lock-hash
+      shell: bash
+      run: |
+        echo "HASH=${{ hashFiles('**/pnpm-lock.yaml') }}" >> $GITHUB_OUTPUT
+
     - uses: actions/cache@v4
       name: Setup pnpm cache
       with:
         path: ${{ steps.pnpm-config.outputs.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-cache-${{ steps.cache-rotation.outputs.YEAR_MONTH }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-store-cache-${{ steps.cache-rotation.outputs.YEAR_MONTH }}-${{ steps.pnpm-lock-hash.outputs.HASH }}
         restore-keys: |
           ${{ runner.os }}-pnpm-store-cache-${{ steps.cache-rotation.outputs.YEAR_MONTH }}-
 


### PR DESCRIPTION
## Summary

`actions/cache@v4` re-evaluates the `key:` template in its **post-step** (cache-save) at job teardown. On some self-hosted / k8s runners (including ours), the workspace is wiped before the post-step runs, so `hashFiles('**/pnpm-lock.yaml')` returns no files and fails the entire job — **even when every real step has already passed**.

## Repro

Real example from `apify-core`: [run 25511344092, cypress shard 6](https://github.com/apify/apify-core/actions/runs/25511344092). All 41 cypress specs passed; the job was then failed by `Post Install dependencies` with:

```
##[error]The template is not valid. apify/workflows/v0.40.0/pnpm-install/action.yaml (Line: 74, Col: 14):
hashFiles('**/pnpm-lock.yaml') failed. Fail to hash files under directory '/home/runner/_work/apify-core/apify-core'
```

## Fix

Capture the hash once in a regular `run:` step (where `hashFiles` is evaluated against the live workspace), expose it as a step output, and reference that output in the cache `key:` instead of re-calling `hashFiles` in the template. Step outputs live in the runner's `_temp/` state and survive workspace teardown, so the post-step evaluation no longer touches the filesystem.

Functionally equivalent on healthy runners — same hash, same cache key, same hit/miss behaviour.

## Test plan

- [ ] Bump consumers to the new tag and re-run a workflow on the affected k8s runners; confirm Post Install dependencies no longer errors.
- [ ] Spot-check a fresh-cache and a warm-cache run for cache hit/miss to confirm key parity.