### PR TITLE
fix(get_values): lowercase clean_branch_name outputs

### DIFF
--- a/.github/workflows/get_values.yaml
+++ b/.github/workflows/get_values.yaml
@@ -19,10 +19,10 @@ on:
         description: Short commit sha
         value: ${{ jobs.get_values.outputs.short_commit_sha }}
       clean_branch_name:
-        description: Branch name stripped of non-alphanumeric characters and capped at length of 35
+        description: Branch name stripped of non-alphanumeric characters, lowercased, and capped at length of 35
         value: ${{ jobs.get_values.outputs.clean_branch_name }}
       clean_branch_name_with_suffix:
-        description: Branch name stripped of non-alphanumeric characters and capped at length of 28 concatenated with first 6 chars of branch SHA
+        description: Branch name stripped of non-alphanumeric characters, lowercased, and capped at length of 28 concatenated with first 6 chars of branch SHA
         value: ${{ jobs.get_values.outputs.clean_branch_name_with_suffix }}
       commit_author:
         description: Author of last commit
@@ -53,6 +53,7 @@ jobs:
           fi
 
           _BRANCH_NAME=${BRANCH_NAME//[^[:alnum:]]/}
+          _BRANCH_NAME=$(echo "${_BRANCH_NAME}" | tr '[:upper:]' '[:lower:]')
           CLEAN_BRANCH_NAME=$(echo ${_BRANCH_NAME} | cut -c 1-35)
           CLEAN_BRANCH_NAME_WITH_SUFFIX=$(echo ${_BRANCH_NAME} | cut -c 1-28)-$(echo ${_BRANCH_NAME} | shasum -a 1 | cut -c 1-6)
 

--- a/.github/workflows/get_values.yaml
+++ b/.github/workflows/get_values.yaml
@@ -22,7 +22,7 @@ on:
         description: Branch name stripped of non-alphanumeric characters, lowercased, and capped at length of 35
         value: ${{ jobs.get_values.outputs.clean_branch_name }}
       clean_branch_name_with_suffix:
-        description: Branch name stripped of non-alphanumeric characters, lowercased, and capped at length of 28 concatenated with first 6 chars of branch SHA
+        description: Branch name stripped of non-alphanumeric characters, lowercased, and capped at length of 28 concatenated with the first 6 hex chars of its SHA-1
         value: ${{ jobs.get_values.outputs.clean_branch_name_with_suffix }}
       commit_author:
         description: Author of last commit


### PR DESCRIPTION
## Summary

Lowercase `clean_branch_name` / `clean_branch_name_with_suffix` at the source so consumers can use them as DNS / Helm release names / npm dist-tags without each call site re-implementing the fix.

Mixed-case branches (e.g. `claude/move-mcp-server-cardRrDNj`) currently break multi-staging deploys and canary npm publishes — see apify/apify-core#27626.

## Backward compatibility

- All-lowercase branches: outputs unchanged (hash input is byte-identical).
- Mixed-case branches: slug changes, but they were already failing — no live state depends on the old form.