### PR TITLE
feat: Use `pnpm config` instead of `npm config`

### DIFF
--- a/pnpm-install/action.yaml
+++ b/pnpm-install/action.yaml
@@ -32,7 +32,7 @@ runs:
       with:
         swap-size-gb: 10
 
-    - uses: pnpm/action-setup@v4.1.0
+    - uses: pnpm/action-setup@v6.0.8
       name: Install pnpm
       with:
         run_install: false
@@ -46,14 +46,11 @@ runs:
     # install step below. Once that step finishes the env var is gone and
     # ~/.npmrc holds an unusable template, so later steps in the same job
     # cannot exfiltrate the token.
-    #
-    # `npm` is always available on the runner via setup-node and is used
-    # here only because corepack-managed pnpm isn't on PATH at every step.
     - name: Configure GitHub npm registry auth
       if: inputs.github-registry-token != ''
       shell: bash
       run: |
-        npm config set '//npm.pkg.github.com/:_authToken=${GITHUB_REGISTRY_TOKEN}'
+        pnpm config set '//npm.pkg.github.com/:_authToken=${GITHUB_REGISTRY_TOKEN}'
 
     - name: Expose pnpm config(s) through "$GITHUB_OUTPUT"
       id: pnpm-config


### PR DESCRIPTION
With PNPM v11 being out, we can use `pnpm config` to set up the registry configuration, and with that use `"onFail": "error"` in the `devEngines.packageManager` config in our projects.

Let's use `pnpm config` in this workflow to allow that. Everyone should update to `pnpm` v11 anyway, so I wouldn't be concerned if this breaks any project.