### PR TITLE
feat: Add `commit-sha` output to the `commit` action

### DIFF
--- a/commit/README.md
+++ b/commit/README.md
@@ -29,6 +29,10 @@ steps:
 - `branch` (optional, default `${{ github.head_ref || github.ref_name }}`) — Target branch name. On pull requests this resolves to the PR's source branch (`github.head_ref`); on other events it resolves to `github.ref_name`. Required when `create-branch` is `true`.
 - `create-branch` (optional, default `false`) — When `true`, the action pushes `HEAD` to `branch` as a new remote branch before committing. `branch` must be passed explicitly in this case.
 
+### Outputs
+
+- `commit-sha` — The SHA of the created commit.
+
 ### Example: commit to a new branch
 
 ```yaml

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -20,6 +20,11 @@ inputs:
     default: 'false'
     required: false
 
+outputs:
+  commit-sha:
+    description: 'The SHA of the created commit.'
+    value: ${{ steps.commit.outputs.commit-sha }}
+
 runs:
   using: composite
   steps:
@@ -50,6 +55,7 @@ runs:
       run: echo "head_ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
     - name: Commit through API
+      id: commit
       uses: actions/github-script@v8
       env:
         COMMIT_MESSAGE: ${{ inputs.commit-message }}


### PR DESCRIPTION
The `commit-sha` output was present only on the step level, not on the action level. This adds it to the action level too.