### PR TITLE
feat: Add more inputs and outputs to the `commit` action to make it more useful

### DIFF
--- a/commit/README.md
+++ b/commit/README.md
@@ -35,7 +35,7 @@ steps:
 
 ### Outputs
 
-- `commit-sha` — The SHA of the created commit. Empty when `committed` is `false`.
+- `commit-sha` — The SHA of the created commit, or the current commit SHA if no new commit was created.
 - `committed` — `'true'` when a commit was created, `'false'` when there were no changes to commit.
 
 ### Example: commit to a new branch

--- a/commit/README.md
+++ b/commit/README.md
@@ -2,7 +2,7 @@
 
 This action creates a commit from the staged files through the GitHub GraphQL API, so the commit is automatically signed by GitHub. The author of the commit will be the identity associated with the provided token (typically `github-actions[bot]` when using `${{ secrets.GITHUB_TOKEN }}`).
 
-By default the action stages everything in the working tree (`git add .`) before committing. Pass the `path` input to scope the staging, or set it to a pathspec that matches nothing if you want to control staging yourself before calling the action.
+By default the action stages everything in the working tree (`git add .`) before committing. Pass the `add` input to scope the staging, or set it to an empty string if you want to control staging yourself before calling the action.
 
 ## Usage
 
@@ -20,7 +20,7 @@ steps:
     with:
       commit-message: "chore: add greeting"
       github-token: ${{ secrets.YOUR_GITHUB_TOKEN_WITH_WRITE_PERMISSION }}
-      path: greeting.txt
+      add: greeting.txt
 ```
 
 ### Inputs
@@ -30,12 +30,13 @@ steps:
 - `repository` (optional, default `${{ github.repository }}`) — Target repository in `<owner>/<repo>` format.
 - `branch` (optional, default `${{ github.head_ref || github.ref_name }}`) — Target branch name. On pull requests this resolves to the PR's source branch (`github.head_ref`); on other events it resolves to `github.ref_name`. Required when `create-branch` is `true`.
 - `create-branch` (optional, default `false`) — When `true`, the action pushes `HEAD` to `branch` as a new remote branch before committing. `branch` must be passed explicitly in this case.
-- `path` (optional, default `.`) — Paths passed to `git add` before committing. Defaults to `.` (everything).
+- `add` (optional, default `.`) — Paths passed to `git add` before committing. Defaults to `.` (everything). When set to an empty string, `git add` is skipped entirely.
 - `pull` (optional, default `''`) — When non-empty, run `git pull <pull>` before staging and committing (e.g. `--rebase --autostash`). The special value `true` runs a plain `git pull` with no arguments. Defaults to an empty string (no pull).
 
 ### Outputs
 
-- `commit-sha` — The SHA of the created commit, or the current commit SHA if no new commit was created.
+- `commit_sha` — The short (7-character) SHA of the created commit, or the current commit SHA if no new commit was created.
+- `commit_long_sha` — The full 40-character SHA of the created commit, or the current commit SHA if no new commit was created.
 - `committed` — `'true'` when a commit was created, `'false'` when there were no changes to commit.
 
 ### Example: commit to a new branch
@@ -55,7 +56,7 @@ steps:
       github-token: ${{ secrets.YOUR_GITHUB_TOKEN_WITH_WRITE_PERMISSION }}
       branch: chore/add-greeting
       create-branch: 'true'
-      path: greeting.txt
+      add: greeting.txt
 ```
 
 ### Example: pull before committing
@@ -77,6 +78,6 @@ steps:
     with:
       commit-message: "chore: add greeting"
       github-token: ${{ secrets.YOUR_GITHUB_TOKEN_WITH_WRITE_PERMISSION }}
-      path: greeting.txt
+      add: greeting.txt
       pull: --rebase --autostash
 ```

--- a/commit/README.md
+++ b/commit/README.md
@@ -2,6 +2,8 @@
 
 This action creates a commit from the staged files through the GitHub GraphQL API, so the commit is automatically signed by GitHub. The author of the commit will be the identity associated with the provided token (typically `github-actions[bot]` when using `${{ secrets.GITHUB_TOKEN }}`).
 
+By default the action stages everything in the working tree (`git add .`) before committing. Pass the `path` input to scope the staging, or set it to a pathspec that matches nothing if you want to control staging yourself before calling the action.
+
 ## Usage
 
 ```yaml
@@ -9,16 +11,16 @@ steps:
   - name: Checkout
     uses: actions/checkout@v6
 
-  - name: Make changes and stage them
+  - name: Make changes
     run: |
       echo "hello" > greeting.txt
-      git add greeting.txt
 
   - name: Commit through API
     uses: apify/workflows/commit@v0.43.0
     with:
       commit-message: "chore: add greeting"
       github-token: ${{ secrets.YOUR_GITHUB_TOKEN_WITH_WRITE_PERMISSION }}
+      path: greeting.txt
 ```
 
 ### Inputs
@@ -28,10 +30,13 @@ steps:
 - `repository` (optional, default `${{ github.repository }}`) — Target repository in `<owner>/<repo>` format.
 - `branch` (optional, default `${{ github.head_ref || github.ref_name }}`) — Target branch name. On pull requests this resolves to the PR's source branch (`github.head_ref`); on other events it resolves to `github.ref_name`. Required when `create-branch` is `true`.
 - `create-branch` (optional, default `false`) — When `true`, the action pushes `HEAD` to `branch` as a new remote branch before committing. `branch` must be passed explicitly in this case.
+- `path` (optional, default `.`) — Paths passed to `git add` before committing. Defaults to `.` (everything).
+- `pull` (optional, default `''`) — When non-empty, run `git pull <pull>` before staging and committing (e.g. `--rebase --autostash`). The special value `true` runs a plain `git pull` with no arguments. Defaults to an empty string (no pull).
 
 ### Outputs
 
-- `commit-sha` — The SHA of the created commit.
+- `commit-sha` — The SHA of the created commit. Empty when `committed` is `false`.
+- `committed` — `'true'` when a commit was created, `'false'` when there were no changes to commit.
 
 ### Example: commit to a new branch
 
@@ -40,16 +45,38 @@ steps:
   - name: Checkout
     uses: actions/checkout@v
 
-  - name: Make changes and stage them
-    run: |
-      echo "hello" > greeting.txt
-      git add greeting.txt
+  - name: Make changes
+    run: echo "hello" > greeting.txt
 
   - name: Commit to a new branch
-    uses: apify/workflows/commit@v0.43.0
+    uses: apify/workflows/commit@v0.45.0
     with:
       commit-message: "chore: add greeting"
       github-token: ${{ secrets.YOUR_GITHUB_TOKEN_WITH_WRITE_PERMISSION }}
       branch: chore/add-greeting
       create-branch: 'true'
+      path: greeting.txt
+```
+
+### Example: pull before committing
+
+When another job may push to the same branch concurrently, use `pull` to fetch the latest changes before committing.
+
+```yaml
+steps:
+  - name: Checkout
+    uses: actions/checkout@v6
+
+  - name: Make changes
+    run: echo "hello" > greeting.txt
+
+  # Someone else would push to the same branch at this point.
+
+  - name: Commit through API
+    uses: apify/workflows/commit@v0.45.0
+    with:
+      commit-message: "chore: add greeting"
+      github-token: ${{ secrets.YOUR_GITHUB_TOKEN_WITH_WRITE_PERMISSION }}
+      path: greeting.txt
+      pull: --rebase --autostash
 ```

--- a/commit/README.md
+++ b/commit/README.md
@@ -16,9 +16,9 @@ steps:
       echo "hello" > greeting.txt
 
   - name: Commit through API
-    uses: apify/workflows/commit@v0.43.0
+    uses: apify/workflows/commit@v0.45.0
     with:
-      commit-message: "chore: add greeting"
+      message: "chore: add greeting"
       github-token: ${{ secrets.YOUR_GITHUB_TOKEN_WITH_WRITE_PERMISSION }}
       add: greeting.txt
 ```
@@ -26,12 +26,13 @@ steps:
 ### Inputs
 
 - `github-token` (required) — Token used to authenticate the GraphQL call. Must have `contents: write` permission on the target repository.
-- `commit-message` (required) — The commit message.
+- `message` (required) — The commit message.
 - `repository` (optional, default `${{ github.repository }}`) — Target repository in `<owner>/<repo>` format.
 - `branch` (optional, default `${{ github.head_ref || github.ref_name }}`) — Target branch name. On pull requests this resolves to the PR's source branch (`github.head_ref`); on other events it resolves to `github.ref_name`. Required when `create-branch` is `true`.
 - `create-branch` (optional, default `false`) — When `true`, the action pushes `HEAD` to `branch` as a new remote branch before committing. `branch` must be passed explicitly in this case.
 - `add` (optional, default `.`) — Paths passed to `git add` before committing. Defaults to `.` (everything). When set to an empty string, `git add` is skipped entirely.
 - `pull` (optional, default `''`) — When non-empty, run `git pull <pull>` before staging and committing (e.g. `--rebase --autostash`). The special value `true` runs a plain `git pull` with no arguments. Defaults to an empty string (no pull).
+- `retries` (optional, default `0`) — How many times to retry the commit if it fails because the branch was updated by another author in the meantime. Requires `pull` to be non-empty (otherwise the action would just re-attempt against the same stale HEAD).
 
 ### Outputs
 
@@ -44,7 +45,7 @@ steps:
 ```yaml
 steps:
   - name: Checkout
-    uses: actions/checkout@v
+    uses: actions/checkout@v6
 
   - name: Make changes
     run: echo "hello" > greeting.txt
@@ -52,7 +53,7 @@ steps:
   - name: Commit to a new branch
     uses: apify/workflows/commit@v0.45.0
     with:
-      commit-message: "chore: add greeting"
+      message: "chore: add greeting"
       github-token: ${{ secrets.YOUR_GITHUB_TOKEN_WITH_WRITE_PERMISSION }}
       branch: chore/add-greeting
       create-branch: 'true'
@@ -61,7 +62,7 @@ steps:
 
 ### Example: pull before committing
 
-When another job may push to the same branch concurrently, use `pull` to fetch the latest changes before committing.
+When another job may push to the same branch concurrently, use `pull` and `retries` to fetch the latest changes before committing.
 
 ```yaml
 steps:
@@ -76,8 +77,11 @@ steps:
   - name: Commit through API
     uses: apify/workflows/commit@v0.45.0
     with:
-      commit-message: "chore: add greeting"
+      message: "chore: add greeting"
       github-token: ${{ secrets.YOUR_GITHUB_TOKEN_WITH_WRITE_PERMISSION }}
       add: greeting.txt
       pull: --rebase --autostash
+      retries: 3
 ```
+
+This will retry the commit up to 3 times if it fails due to the branch being updated by another author, waiting with exponential backoff between attempts. The `pull` input is required for retries to work, as the action needs to fetch the new HEAD between attempts to avoid retrying against the same stale commit.

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -4,7 +4,7 @@ inputs:
   github-token:
     description: 'Token to authenticate API calls'
     required: true
-  commit-message:
+  message:
     required: true
     description: 'The commit message'
   repository:
@@ -26,6 +26,10 @@ inputs:
   pull:
     description: 'When non-empty, run `git pull <pull>` before staging and committing (e.g. `--rebase --autostash`). The special value `true` runs a plain `git pull` with no arguments. Defaults to an empty string (no pull).'
     default: ''
+    required: false
+  retries:
+    description: 'How many times to retry the commit if it fails because the branch was updated by another author in the meantime. Requires `pull` to be non-empty (so the action can fetch the new HEAD between attempts). Defaults to `0` (no retries).'
+    default: '0'
     required: false
 
 outputs:
@@ -79,19 +83,16 @@ runs:
       run: |
         git add ${{ inputs.add }}
 
-    - name: Get HEAD SHA
-      id: get-head-sha
-      shell: bash
-      run: echo "head_ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
     - name: Commit through API
       id: commit
       uses: actions/github-script@v8
       env:
-        COMMIT_MESSAGE: ${{ inputs.commit-message }}
+        COMMIT_MESSAGE: ${{ inputs.message }}
         REPO: ${{ inputs.repository }}
-        EXPECTED_HEAD_OID: ${{ steps.get-head-sha.outputs.head_ref }}
         BRANCH: ${{ inputs.branch }}
+        ADD: ${{ inputs.add }}
+        PULL: ${{ inputs.pull }}
+        RETRIES: ${{ inputs.retries }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -19,8 +19,8 @@ inputs:
     description: 'Create branch if it does not exist. When `true`, `branch` must be passed explicitly.'
     default: 'false'
     required: false
-  path:
-    description: 'Paths to stage before committing, passed to `git add`. Defaults to `.` (everything).'
+  add:
+    description: 'Paths to stage before committing, passed to `git add`. Defaults to `.` (everything). When set to an empty string, `git add` is not called.'
     default: '.'
     required: false
   pull:
@@ -29,9 +29,12 @@ inputs:
     required: false
 
 outputs:
-  commit-sha:
-    description: 'The SHA of the created commit. Empty when `committed` is `false`.'
-    value: ${{ steps.commit.outputs.commit-sha }}
+  commit_sha:
+    description: 'The short (7-character) SHA of the created commit. Falls back to the current HEAD SHA when no commit was made.'
+    value: ${{ steps.commit.outputs.commit_sha }}
+  commit_long_sha:
+    description: 'The full 40-character SHA of the created commit. Falls back to the current HEAD SHA when no commit was made.'
+    value: ${{ steps.commit.outputs.commit_long_sha }}
   committed:
     description: '`true` when a commit was created, `false` when there were no staged changes to commit.'
     value: ${{ steps.commit.outputs.committed }}
@@ -71,9 +74,10 @@ runs:
         fi
 
     - name: Stage files
+      if: ${{ inputs.add != '' }}
       shell: bash
       run: |
-        git add ${{ inputs.path }}
+        git add ${{ inputs.add }}
 
     - name: Get HEAD SHA
       id: get-head-sha

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -19,11 +19,22 @@ inputs:
     description: 'Create branch if it does not exist. When `true`, `branch` must be passed explicitly.'
     default: 'false'
     required: false
+  path:
+    description: 'Paths to stage before committing, passed to `git add`. Defaults to `.` (everything).'
+    default: '.'
+    required: false
+  pull:
+    description: 'When non-empty, run `git pull <pull>` before staging and committing (e.g. `--rebase --autostash`). The special value `true` runs a plain `git pull` with no arguments. Defaults to an empty string (no pull).'
+    default: ''
+    required: false
 
 outputs:
   commit-sha:
-    description: 'The SHA of the created commit.'
+    description: 'The SHA of the created commit. Empty when `committed` is `false`.'
     value: ${{ steps.commit.outputs.commit-sha }}
+  committed:
+    description: '`true` when a commit was created, `false` when there were no staged changes to commit.'
+    value: ${{ steps.commit.outputs.committed }}
 
 runs:
   using: composite
@@ -48,6 +59,21 @@ runs:
       shell: bash
       run: |
         git checkout "${{ inputs.branch }}"
+
+    - name: Pull latest changes
+      if: ${{ inputs.pull != '' }}
+      shell: bash
+      run: |
+        if [[ "${{ inputs.pull }}" == "true" ]]; then
+          git pull
+        else
+          git pull ${{ inputs.pull }}
+        fi
+
+    - name: Stage files
+      shell: bash
+      run: |
+        git add ${{ inputs.path }}
 
     - name: Get HEAD SHA
       id: get-head-sha

--- a/commit/index.mts
+++ b/commit/index.mts
@@ -90,6 +90,13 @@ export async function main({ github, env, core }: { github: Octokit, env: Record
     };
     core.info(`committing file changes: "${JSON.stringify(changedPaths, null, 4)}"`);
 
+    if (fileChanges.additions.length === 0 && fileChanges.deletions.length === 0) {
+        core.info('no staged changes — skipping commit');
+        core.setOutput('committed', 'false');
+        core.setOutput('commit-sha', '');
+        return;
+    }
+
     const commitMessageLines = COMMIT_MESSAGE.split('\n');
     const messageTitle = commitMessageLines[0];
     const messageBody = commitMessageLines.slice(1).join('\n').trim();
@@ -121,6 +128,7 @@ export async function main({ github, env, core }: { github: Octokit, env: Record
     core.info(`successfully pushed commit "${commitSha}"`);
 
     core.setOutput('commit-sha', commitSha);
+    core.setOutput('committed', 'true');
 }
 
 /**

--- a/commit/index.mts
+++ b/commit/index.mts
@@ -92,8 +92,9 @@ export async function main({ github, env, core }: { github: Octokit, env: Record
 
     if (fileChanges.additions.length === 0 && fileChanges.deletions.length === 0) {
         core.info('no staged changes — skipping commit');
+        const currentHeadSha = (await exec('git rev-parse HEAD', { encoding: 'utf8' })).stdout.trim();
         core.setOutput('committed', 'false');
-        core.setOutput('commit-sha', '');
+        core.setOutput('commit-sha', currentHeadSha);
         return;
     }
 

--- a/commit/index.mts
+++ b/commit/index.mts
@@ -49,91 +49,6 @@ export function checkSupportedFileModes(status: GitFileStatus) {
     }
 }
 
-export async function main({ github, env, core }: { github: Octokit, env: Record<string, string>, core: typeof Core }) {
-    const {
-        COMMIT_MESSAGE,
-        REPO,
-        EXPECTED_HEAD_OID,
-        BRANCH,
-    } = env;
-
-    const fileChanges: FileChanges = { additions: [], deletions: [] };
-    const stagedFiles = await status();
-
-    for (const file of stagedFiles) {
-        checkSupportedFileModes(file);
-        const { filePath, fileStatus } = file;
-
-        switch (fileStatus) {
-            case FILE_STATUS.ADDED:
-            case FILE_STATUS.MODIFIED:
-                fileChanges.additions.push({
-                    path: filePath,
-                    contents: await fs.readFile(filePath, { encoding: 'base64' }),
-                });
-
-                break;
-
-            case FILE_STATUS.DELETED:
-                fileChanges.deletions.push({ path: filePath });
-                break;
-
-            default:
-                throw new Error(`unexpected file status "${fileStatus}"`);
-        }
-    }
-
-    // Only log file paths not the base64 encoded file contents.
-    const changedPaths = {
-        additions: fileChanges.additions.map(({ path }) => path),
-        deletions: fileChanges.deletions.map(({ path }) => path),
-    };
-    core.info(`committing file changes: "${JSON.stringify(changedPaths, null, 4)}"`);
-
-    if (fileChanges.additions.length === 0 && fileChanges.deletions.length === 0) {
-        core.info('no staged changes — skipping commit');
-        const currentHeadSha = (await exec('git rev-parse HEAD', { encoding: 'utf8' })).stdout.trim();
-        core.setOutput('committed', 'false');
-        core.setOutput('commit_sha', currentHeadSha.slice(0, 7));
-        core.setOutput('commit_long_sha', currentHeadSha);
-        return;
-    }
-
-    const commitMessageLines = COMMIT_MESSAGE.split('\n');
-    const messageTitle = commitMessageLines[0];
-    const messageBody = commitMessageLines.slice(1).join('\n').trim();
-
-    const response = await github.graphql(`\
-        mutation Commit($input: CreateCommitOnBranchInput!) {
-            createCommitOnBranch(input: $input) {
-                commit {
-                    oid
-                }
-            }
-        }
-    `, {
-        input: {
-            fileChanges,
-            branch: {
-                branchName: BRANCH,
-                repositoryNameWithOwner: REPO,
-            },
-            expectedHeadOid: EXPECTED_HEAD_OID,
-            message: {
-                headline: messageTitle,
-                body: messageBody,
-            },
-        },
-    }) as any;
-
-    const commitSha = response.createCommitOnBranch.commit.oid;
-    core.info(`successfully pushed commit "${commitSha}"`);
-
-    core.setOutput('commit_sha', commitSha.slice(0, 7));
-    core.setOutput('commit_long_sha', commitSha);
-    core.setOutput('committed', 'true');
-}
-
 /**
  * Produces the list of staged files for committing.
  */
@@ -169,4 +84,148 @@ export async function status(options: Omit<childProcess.ExecOptions, 'encoding'>
             };
         })
         .filter((it) => !!it);
+}
+
+async function collectFileChanges(): Promise<FileChanges> {
+    const fileChanges: FileChanges = { additions: [], deletions: [] };
+    const stagedFiles = await status();
+
+    for (const file of stagedFiles) {
+        checkSupportedFileModes(file);
+        const { filePath, fileStatus } = file;
+
+        switch (fileStatus) {
+            case FILE_STATUS.ADDED:
+            case FILE_STATUS.MODIFIED:
+                fileChanges.additions.push({
+                    path: filePath,
+                    contents: await fs.readFile(filePath, { encoding: 'base64' }),
+                });
+
+                break;
+
+            case FILE_STATUS.DELETED:
+                fileChanges.deletions.push({ path: filePath });
+                break;
+
+            default:
+                throw new Error(`unexpected file status "${fileStatus}"`);
+        }
+    }
+
+    return fileChanges;
+}
+
+const RETRY_BASE_DELAY_MS = 1000;
+
+type CreateCommitArgs = {
+    github: Octokit;
+    repo: string;
+    branch: string;
+    expectedHeadOid: string;
+    messageTitle: string;
+    messageBody: string;
+    fileChanges: FileChanges;
+};
+
+async function createCommit({ github, repo, branch, expectedHeadOid, messageTitle, messageBody, fileChanges }: CreateCommitArgs): Promise<string> {
+    const response = await github.graphql(`\
+        mutation Commit($input: CreateCommitOnBranchInput!) {
+            createCommitOnBranch(input: $input) {
+                commit {
+                    oid
+                }
+            }
+        }
+    `, {
+        input: {
+            fileChanges,
+            branch: {
+                branchName: branch,
+                repositoryNameWithOwner: repo,
+            },
+            expectedHeadOid,
+            message: {
+                headline: messageTitle,
+                body: messageBody,
+            },
+        },
+    }) as any;
+
+    return response.createCommitOnBranch.commit.oid;
+}
+
+export async function main({ github, env, core }: { github: Octokit, env: Record<string, string>, core: typeof Core }) {
+    const {
+        COMMIT_MESSAGE,
+        REPO,
+        BRANCH,
+        PULL = '',
+        RETRIES = '0',
+    } = env;
+
+    const retries = parseInt(RETRIES, 10);
+    if (Number.isNaN(retries) || retries < 0) {
+        throw new Error(`'retries' must be a non-negative integer, got "${RETRIES}"`);
+    }
+    if (retries > 0 && PULL === '') {
+        throw new Error(`'retries' is set to ${retries} but 'pull' is empty — retrying requires 'pull' to be set so the action can fetch the new HEAD between attempts.`);
+    }
+
+    const commitMessageLines = COMMIT_MESSAGE.split('\n');
+    const messageTitle = commitMessageLines[0];
+    const messageBody = commitMessageLines.slice(1).join('\n').trim();
+
+    const maxAttempts = retries + 1;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        if (PULL !== '') {
+            const pullCmd = PULL === 'true' ? 'git pull' : `git pull ${PULL}`;
+            core.info(`Executing "${pullCmd}" before committing (attempt ${attempt}/${maxAttempts})`);
+            await exec(pullCmd, { encoding: 'utf8' });
+        }
+
+        const expectedHeadOid = (await exec('git rev-parse HEAD', { encoding: 'utf8' })).stdout.trim();
+        const fileChanges = await collectFileChanges();
+
+        // Only log file paths not the base64 encoded file contents.
+        const changedPaths = {
+            additions: fileChanges.additions.map(({ path }) => path),
+            deletions: fileChanges.deletions.map(({ path }) => path),
+        };
+        core.info(`committing file changes: "${JSON.stringify(changedPaths, null, 4)}"`);
+
+        if (fileChanges.additions.length === 0 && fileChanges.deletions.length === 0) {
+            core.info('no staged changes — skipping commit');
+            core.setOutput('committed', 'false');
+            core.setOutput('commit_sha', expectedHeadOid.slice(0, 7));
+            core.setOutput('commit_long_sha', expectedHeadOid);
+            return;
+        }
+
+        try {
+            const commitSha = await createCommit({
+                github,
+                repo: REPO,
+                branch: BRANCH,
+                expectedHeadOid,
+                messageTitle,
+                messageBody,
+                fileChanges,
+            });
+            core.info(`successfully pushed commit "${commitSha}"`);
+
+            core.setOutput('commit_sha', commitSha.slice(0, 7));
+            core.setOutput('commit_long_sha', commitSha);
+            core.setOutput('committed', 'true');
+            return;
+        } catch (err) {
+            if (attempt < maxAttempts) {
+                const delayMs = RETRY_BASE_DELAY_MS * (2 ** (attempt - 1));
+                core.warning(`commit attempt ${attempt}/${maxAttempts} failed: ${err instanceof Error ? err.message : String(err)} — retrying in ${delayMs}ms`);
+                await new Promise((resolve) => { setTimeout(resolve, delayMs); });
+                continue;
+            }
+            throw err;
+        }
+    }
 }

--- a/commit/index.mts
+++ b/commit/index.mts
@@ -94,7 +94,8 @@ export async function main({ github, env, core }: { github: Octokit, env: Record
         core.info('no staged changes — skipping commit');
         const currentHeadSha = (await exec('git rev-parse HEAD', { encoding: 'utf8' })).stdout.trim();
         core.setOutput('committed', 'false');
-        core.setOutput('commit-sha', currentHeadSha);
+        core.setOutput('commit_sha', currentHeadSha.slice(0, 7));
+        core.setOutput('commit_long_sha', currentHeadSha);
         return;
     }
 
@@ -128,7 +129,8 @@ export async function main({ github, env, core }: { github: Octokit, env: Record
     const commitSha = response.createCommitOnBranch.commit.oid;
     core.info(`successfully pushed commit "${commitSha}"`);
 
-    core.setOutput('commit-sha', commitSha);
+    core.setOutput('commit_sha', commitSha.slice(0, 7));
+    core.setOutput('commit_long_sha', commitSha);
     core.setOutput('committed', 'true');
 }
 

--- a/commit/index.test.mts
+++ b/commit/index.test.mts
@@ -128,6 +128,8 @@ describe('signed commit action', () => {
         const graphql = vi.fn();
         const fakeGithub = { graphql };
 
+        const headSha = (await doExec('git rev-parse HEAD')).stdout.trim();
+
         const originalCwd = process.cwd();
         try {
             process.chdir(repoDir);
@@ -147,7 +149,7 @@ describe('signed commit action', () => {
 
         expect(graphql).not.toHaveBeenCalled();
         expect(outputs.committed).toEqual('false');
-        expect(outputs['commit-sha']).toEqual('');
+        expect(outputs['commit-sha']).toEqual(headSha);
     });
 
     it('checks file modes and does not throw when correct', async () => {

--- a/commit/index.test.mts
+++ b/commit/index.test.mts
@@ -4,9 +4,9 @@ import * as os from 'node:os';
 import * as fs from 'node:fs/promises';
 import * as childProcess from 'node:child_process';
 
-import { describe, afterEach, beforeEach, it, expect } from 'vitest';
+import { describe, afterEach, beforeEach, it, expect, vi } from 'vitest';
 
-import { status, FILE_STATUS, checkSupportedFileModes } from './index.mts';
+import { status, FILE_STATUS, checkSupportedFileModes, main } from './index.mts';
 
 const exec = util.promisify(childProcess.exec);
 
@@ -117,6 +117,37 @@ describe('signed commit action', () => {
         const statuses = await status({ cwd: repoDir });
 
         expect(() => statuses.forEach(checkSupportedFileModes)).toThrow();
+    });
+
+    it('skips the commit and sets committed=false when nothing is staged', async () => {
+        const outputs: Record<string, string> = {};
+        const fakeCore = {
+            info: () => {},
+            setOutput: (name: string, value: string) => { outputs[name] = value; },
+        };
+        const graphql = vi.fn();
+        const fakeGithub = { graphql };
+
+        const originalCwd = process.cwd();
+        try {
+            process.chdir(repoDir);
+            await main({
+                github: fakeGithub as any,
+                core: fakeCore as any,
+                env: {
+                    COMMIT_MESSAGE: 'chore: nothing',
+                    REPO: 'apify/workflows',
+                    EXPECTED_HEAD_OID: 'abcd1234',
+                    BRANCH: 'main',
+                },
+            });
+        } finally {
+            process.chdir(originalCwd);
+        }
+
+        expect(graphql).not.toHaveBeenCalled();
+        expect(outputs.committed).toEqual('false');
+        expect(outputs['commit-sha']).toEqual('');
     });
 
     it('checks file modes and does not throw when correct', async () => {

--- a/commit/index.test.mts
+++ b/commit/index.test.mts
@@ -149,7 +149,8 @@ describe('signed commit action', () => {
 
         expect(graphql).not.toHaveBeenCalled();
         expect(outputs.committed).toEqual('false');
-        expect(outputs['commit-sha']).toEqual(headSha);
+        expect(outputs['commit_sha']).toEqual(headSha.slice(0, 7));
+        expect(outputs['commit_long_sha']).toEqual(headSha);
     });
 
     it('checks file modes and does not throw when correct', async () => {

--- a/commit/index.test.mts
+++ b/commit/index.test.mts
@@ -139,7 +139,6 @@ describe('signed commit action', () => {
                 env: {
                     COMMIT_MESSAGE: 'chore: nothing',
                     REPO: 'apify/workflows',
-                    EXPECTED_HEAD_OID: 'abcd1234',
                     BRANCH: 'main',
                 },
             });
@@ -151,6 +150,51 @@ describe('signed commit action', () => {
         expect(outputs.committed).toEqual('false');
         expect(outputs['commit_sha']).toEqual(headSha.slice(0, 7));
         expect(outputs['commit_long_sha']).toEqual(headSha);
+    });
+
+    it('throws when retries > 0 but pull is empty', async () => {
+        const fakeCore = { info: () => {}, warning: () => {}, setOutput: () => {} };
+        const fakeGithub = { graphql: vi.fn() };
+
+        const originalCwd = process.cwd();
+        try {
+            process.chdir(repoDir);
+            await expect(main({
+                github: fakeGithub as any,
+                core: fakeCore as any,
+                env: {
+                    COMMIT_MESSAGE: 'chore: x',
+                    REPO: 'apify/workflows',
+                    BRANCH: 'main',
+                    RETRIES: '2',
+                    PULL: '',
+                },
+            })).rejects.toThrow(/retries.*pull/i);
+        } finally {
+            process.chdir(originalCwd);
+        }
+    });
+
+    it('throws when retries is not a non-negative integer', async () => {
+        const fakeCore = { info: () => {}, warning: () => {}, setOutput: () => {} };
+        const fakeGithub = { graphql: vi.fn() };
+
+        const originalCwd = process.cwd();
+        try {
+            process.chdir(repoDir);
+            await expect(main({
+                github: fakeGithub as any,
+                core: fakeCore as any,
+                env: {
+                    COMMIT_MESSAGE: 'chore: x',
+                    REPO: 'apify/workflows',
+                    BRANCH: 'main',
+                    RETRIES: 'banana',
+                },
+            })).rejects.toThrow(/non-negative integer/);
+        } finally {
+            process.chdir(originalCwd);
+        }
     });
 
     it('checks file modes and does not throw when correct', async () => {


### PR DESCRIPTION
In https://github.com/apify/store-website-content-crawler/pull/753#discussion_r3240499474, we've decided to add a few inputs and outputs to the shared `commit` action to enable easier usage of it.

The changes are:
- added `path` input specifying which files should be staged before the commit
- added `pull` input specifying whether to call `git pull` before the commit and with what parameters
- added `retries` input specifying how many retries to do in case of errors
- renamed `commit-message` input to `message`
- added `committed` output saying `true` / `false` whether the commit actually happened, or whether there were no changes
- changed `commit-sha` output to `commit_sha`, and it contains the short SHA
- added `commit_long_sha` output

They mirror the interface of `EndBug/add-and-commit` for an easier migration from that action.