### PR TITLE
fix(get_values): use head ref/sha on pull_request_target

### DIFF
--- a/.github/workflows/get_values.yaml
+++ b/.github/workflows/get_values.yaml
@@ -44,8 +44,7 @@ jobs:
           if [ "${{ inputs.commitSha }}" != "" ]; then
               COMMIT_SHA=${{ inputs.commitSha }}
               BRANCH_NAME=${GITHUB_REF_NAME}
-          # pull_request_target carries the same head context as pull_request (GITHUB_HEAD_REF / head.sha);
-          # without this it falls through to the base branch below, breaking per-PR naming (e.g. env teardowns).
+          # pull_request_target exposes the same head ref/sha as pull_request; without this it falls through to the base branch.
           elif [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "pull_request_target" ]; then
               COMMIT_SHA=${{ github.event.pull_request.head.sha }}
               BRANCH_NAME=${GITHUB_HEAD_REF}

--- a/.github/workflows/get_values.yaml
+++ b/.github/workflows/get_values.yaml
@@ -44,7 +44,9 @@ jobs:
           if [ "${{ inputs.commitSha }}" != "" ]; then
               COMMIT_SHA=${{ inputs.commitSha }}
               BRANCH_NAME=${GITHUB_REF_NAME}
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+          # pull_request_target carries the same head context as pull_request (GITHUB_HEAD_REF / head.sha);
+          # without this it falls through to the base branch below, breaking per-PR naming (e.g. env teardowns).
+          elif [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "pull_request_target" ]; then
               COMMIT_SHA=${{ github.event.pull_request.head.sha }}
               BRANCH_NAME=${GITHUB_HEAD_REF}
           else


### PR DESCRIPTION
On `pull_request_target`, `get_values` fell through to the `else` branch and read `GITHUB_REF_NAME` — the **base** branch (e.g. `develop`) — so `clean_branch_name`, `clean_branch_name_with_suffix`, and `short_commit_sha` reflected the target branch instead of the PR's head.

`GITHUB_HEAD_REF` and `github.event.pull_request.head.sha` are populated for **both** `pull_request` and `pull_request_target`, so this just handles them the same way.

**Impact / audit:** the only consumer that calls `get_values` on `pull_request_target` is apify-core's `teardown_multi_staging.yaml` (org-wide search for both terms returns nothing else; every other consumer uses `pull_request`/push). That teardown *wants* the head ref — it currently computes `*-develop-<hash>` and no-ops, orphaning multi-staging envs until the weekly scheduled sweep. So this change only affects that workflow, in the intended direction.

Closes #302. After release, apify-core drops its interim `compute_prefix` workaround and apify-web's teardown can move to `pull_request_target`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)