### PR TITLE
feat: update CFN lint

### DIFF
--- a/.github/workflows/lint_cloudformation.yaml
+++ b/.github/workflows/lint_cloudformation.yaml
@@ -17,7 +17,7 @@ on:
 
 env:
   # renovate: datasource=pypi depName=cfn-lint
-  CFN_LINT_VERSION: 0.87.3
+  CFN_LINT_VERSION: 1.51.4
 
 jobs:
   lint:


### PR DESCRIPTION
Updating so that CFN lint does not produce false-positives on newer CloudFormation constructs like `NestedVirtualization`