### PR TITLE
fix: ensure the committed changelog ends with a trailing newline

### DIFF
--- a/.github/workflows/python_bump_and_update_changelog.yaml
+++ b/.github/workflows/python_bump_and_update_changelog.yaml
@@ -114,6 +114,15 @@ jobs:
           write-mode: overwrite
           contents: ${{ inputs.changelog }}
 
+      # The 'changelog' input travels through a $GITHUB_OUTPUT heredoc, which strips the trailing
+      # newline, so the input path above writes the file without one. Normalize here so the committed
+      # changelog always ends with a newline, whichever path wrote it.
+      - name: Ensure the changelog ends with a newline
+        shell: bash
+        env:
+          CHANGELOG_PATH: ${{ inputs.changelog_path }}
+        run: sed -i -e '$a\' "${CHANGELOG_PATH}"
+
       - name: Commit changes
         id: commit
         uses: apify/actions/signed-commit@v1.0.0


### PR DESCRIPTION
The artifact path already produces a changelog ending with a newline, but the deprecated `changelog`-input fallback does not: the value travels through a `$GITHUB_OUTPUT` heredoc, which strips the final newline, so every release commit made through that path rewrites the last line of `CHANGELOG.md`. Adds a normalization step before the commit so the committed changelog always ends with a newline, whichever path wrote it.

*✍️ Drafted by Claude Code*