### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/build_docker_image_and_push_to_ecr.yaml
+++ b/.github/workflows/build_docker_image_and_push_to_ecr.yaml
@@ -109,7 +109,7 @@ jobs:
     steps:
       - name: Send notification to slack
         if: inputs.slackChannelId != ''
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.slackToken }}
@@ -148,7 +148,7 @@ jobs:
             }
 
       - name: clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: set docker build args and secrets
         run: |
@@ -168,15 +168,15 @@ jobs:
 
       # NOTE: can be useful
       # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v2
+      #   uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
 
       - name: setup Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       # First assume GithubOIDCRole role, the trust relationship between GitHub and AWS is defined in IAM GithubOIDCRole in the organization account. This role has permissions to assume Deployer roles only.
       - name: assume GithubOIDCRole
         if: inputs.useOIDC == true
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: ${{ inputs.awsRegion }}
           role-to-assume: ${{ inputs.githubOIDCRoleArn }}
@@ -189,7 +189,7 @@ jobs:
       # Then assume Deployer role, which can be assumed by GithubOIDCRole and has all the permissions needed to deploy cloudformation stacks.
       - name: assume Deployer role
         if: inputs.useOIDC == true
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: ${{ inputs.awsRegion }}
           role-to-assume: ${{ inputs.awsRoleArn }}
@@ -200,11 +200,11 @@ jobs:
       - name: login to AWS ECR using OIDC
         if: inputs.useOIDC == true
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2.1.7
 
       - name: login to AWS ECR
         if: inputs.useOIDC == false
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -212,7 +212,7 @@ jobs:
 
       - name: build and push
         id: build_and_push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ inputs.dockerContext }}
           file: ${{ inputs.dockerFilePath }}
@@ -238,7 +238,7 @@ jobs:
 
       - name: send result to slack
         if: always() && inputs.slackChannelId != ''
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.slackToken }}

--- a/.github/workflows/check-execute-workflow-dist.yaml
+++ b/.github/workflows/check-execute-workflow-dist.yaml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/claude-md-maintenance.yml
+++ b/.github/workflows/claude-md-maintenance.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "24"
 

--- a/.github/workflows/copy_proofread_review.yaml
+++ b/.github/workflows/copy_proofread_review.yaml
@@ -58,7 +58,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           # The diff comes from `gh pr diff` (API-backed) and files are read from the working tree.
           fetch-depth: 1
@@ -66,7 +66,7 @@ jobs:
       - name: Check out the apify-proofreader skill
         # Checked out here rather than under `.claude/` — claude-code-action wipes and restores `.claude/`
         # from the PR base branch before running Claude.
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: apify/agent-skills-internal
           token: ${{ secrets.agentSkillsRepoGithubToken }}
@@ -75,7 +75,7 @@ jobs:
           fetch-depth: 1
 
       - name: Proofread public-facing copy
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5ee796a55f92566ecd7e39d70dd613abcbea0d7c # v1.0.197
         env:
           GH_TOKEN: ${{ github.token }}
         with:
@@ -155,7 +155,7 @@ jobs:
       - name: Remove trigger label
         # Re-adding it re-runs the review.
         if: always() && github.event.label.name != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ github.token }}
           script: |

--- a/.github/workflows/create_changelog.yaml
+++ b/.github/workflows/create_changelog.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: report failure to slack
         if: failure() && inputs.slackChannelIdForFailureMsg != ''
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.slackToken }}

--- a/.github/workflows/deploy_cloudformation.yaml
+++ b/.github/workflows/deploy_cloudformation.yaml
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: send notification to slack
         if: inputs.slackChannelId != ''
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.slackToken }}
@@ -139,11 +139,11 @@ jobs:
             }
 
       - name: clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: assume IAM role
         if: inputs.useOIDC == false
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.awsAccessKeyId }}
           aws-secret-access-key: ${{ secrets.awsSecretAccessKey }}
@@ -158,7 +158,7 @@ jobs:
       # First assume GithubOIDCRole role, the trust relationship between GitHub and AWS is defined in IAM GithubOIDCRole in the organization account. This role has permissions to assume Deployer roles only.
       - name: assume GithubOIDCRole
         if: inputs.useOIDC == true
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: ${{ inputs.awsRegion }}
           role-to-assume: ${{ inputs.githubOIDCRoleArn }}
@@ -171,7 +171,7 @@ jobs:
       # Then assume Deployer role, which can be assumed by GithubOIDCRole and has all the permissions needed to deploy cloudformation stacks.
       - name: assume Deployer role
         if: inputs.useOIDC == true
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: ${{ inputs.awsRegion }}
           role-to-assume: ${{ inputs.awsRoleArn }}
@@ -257,7 +257,7 @@ jobs:
 
       - name: send result to slack
         if: always() && inputs.slackChannelId != ''
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.slackToken }}

--- a/.github/workflows/deploy_helmfile.yaml
+++ b/.github/workflows/deploy_helmfile.yaml
@@ -129,11 +129,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Send notification to slack
         if: inputs.slackChannelId != ''
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.slackToken }}
@@ -208,7 +208,7 @@ jobs:
 
       - name: assume IAM role
         if: inputs.useOIDC == false
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.awsAccessKeyId }}
           aws-secret-access-key: ${{ secrets.awsSecretAccessKey }}
@@ -223,7 +223,7 @@ jobs:
       # First assume GithubOIDCRole role, the trust relationship between GitHub and AWS is defined in IAM GithubOIDCRole in the organization account. This role has permissions to assume Deployer roles only.
       - name: assume GithubOIDCRole
         if: inputs.useOIDC == true
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: ${{ inputs.awsRegion }}
           role-to-assume: ${{ inputs.githubOIDCRoleArn }}
@@ -236,7 +236,7 @@ jobs:
       # Then assume Deployer role, which can be assumed by GithubOIDCRole and has all the permissions needed to deploy cloudformation stacks.
       - name: assume Deployer role
         if: inputs.useOIDC == true
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: ${{ inputs.awsRegion }}
           role-to-assume: ${{ inputs.awsRoleArn }}
@@ -248,7 +248,7 @@ jobs:
         run: aws eks update-kubeconfig --name ${{ inputs.eksClusterName }} $OPTIONAL_PARAMS
 
       - name: Tailscale VPN
-        uses: tailscale/github-action@v4
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
         if: inputs.enableVpn == 'true'
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
@@ -296,7 +296,7 @@ jobs:
 
       - name: send result to slack
         if: always() && inputs.slackChannelId != ''
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.slackToken }}

--- a/.github/workflows/get_values.yaml
+++ b/.github/workflows/get_values.yaml
@@ -64,7 +64,7 @@ jobs:
           echo "clean_branch_name_with_suffix=${CLEAN_BRANCH_NAME_WITH_SUFFIX}" >> $GITHUB_OUTPUT
 
       - name: get last commit author
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: get_commit_author
         with:
           result-encoding: string

--- a/.github/workflows/invalidate_cloudfront.yaml
+++ b/.github/workflows/invalidate_cloudfront.yaml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: assume IAM role
         if: inputs.useOIDC == false
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.awsAccessKeyId }}
           aws-secret-access-key: ${{ secrets.awsSecretAccessKey }}
@@ -81,7 +81,7 @@ jobs:
       # First assume GithubOIDCRole role, the trust relationship between GitHub and AWS is defined in IAM GithubOIDCRole in the organization account. This role has permissions to assume Deployer roles only.
       - name: assume GithubOIDCRole
         if: inputs.useOIDC == true
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: ${{ inputs.awsRegion }}
           role-to-assume: ${{ inputs.githubOIDCRoleArn }}
@@ -94,7 +94,7 @@ jobs:
       # Then assume Deployer role, which can be assumed by GithubOIDCRole and has all the permissions needed.
       - name: assume Deployer role
         if: inputs.useOIDC == true
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: ${{ inputs.awsRegion }}
           role-to-assume: ${{ inputs.awsRoleArn }}

--- a/.github/workflows/lint_cloudformation.yaml
+++ b/.github/workflows/lint_cloudformation.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04-arm64
     steps:
       - name: clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: install cfn-lint
         run: pip install cfn-lint==${CFN_LINT_VERSION}

--- a/.github/workflows/lint_gh_actions.yaml
+++ b/.github/workflows/lint_gh_actions.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04-arm64
     steps:
       - name: clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: lint
         run: |

--- a/.github/workflows/lint_helmfile.yaml
+++ b/.github/workflows/lint_helmfile.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04-arm64
     steps:
       - name: clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: install helmfile
         run: |

--- a/.github/workflows/local_lint.yaml
+++ b/.github/workflows/local_lint.yaml
@@ -21,16 +21,16 @@ jobs:
     runs-on: ubuntu-22.04-arm64
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: '.nvmrc'
           check-latest: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/local_release.yaml
+++ b/.github/workflows/local_release.yaml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: release-please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           release-type: simple

--- a/.github/workflows/python_bump_and_update_changelog.yaml
+++ b/.github/workflows/python_bump_and_update_changelog.yaml
@@ -45,17 +45,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ inputs.python_version }}
 
       - name: Set up uv package manager
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: ${{ inputs.python_version }}
 
@@ -71,7 +71,7 @@ jobs:
       # 128 KiB - past that the step fails to start with "Argument list too long".
       - name: Download changelog artifact
         id: changelog_artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           name: ${{ inputs.changelog_artifact_name }}
@@ -108,7 +108,7 @@ jobs:
       # not upload the artifact. Drop it, together with the 'changelog' input, once every caller is bumped.
       - name: Update the changelog from the input
         if: ${{ steps.changelog_artifact.outcome != 'success' }}
-        uses: DamianReeves/write-file-action@v1.3
+        uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 # v1.3
         with:
           path: ${{ inputs.changelog_path }}
           write-mode: overwrite

--- a/.github/workflows/python_docs_check.yaml
+++ b/.github/workflows/python_docs_check.yaml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: ${{ inputs.node_version }}
 
@@ -48,12 +48,12 @@ jobs:
           corepack prepare yarn@stable --activate
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ inputs.python_version }}
 
       - name: Set up uv package manager
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: ${{ inputs.python_version }}
 

--- a/.github/workflows/python_integration_tests.yaml
+++ b/.github/workflows/python_integration_tests.yaml
@@ -78,15 +78,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up uv package manager
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -110,7 +110,7 @@ jobs:
             matrix.python-version == inputs.python_version_for_codecov &&
             env.CODECOV_TOKEN != ''
           }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           token: ${{ env.CODECOV_TOKEN }}
           files: coverage-integration.xml

--- a/.github/workflows/python_lint_check.yaml
+++ b/.github/workflows/python_lint_check.yaml
@@ -28,15 +28,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up uv package manager
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python_type_check.yaml
+++ b/.github/workflows/python_type_check.yaml
@@ -28,15 +28,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up uv package manager
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python_unit_tests.yaml
+++ b/.github/workflows/python_unit_tests.yaml
@@ -67,15 +67,15 @@ jobs:
           sudo killall Finder spindump ecosystemanalyticsd SystemUIServer NotificationCenter mds mds_stores mds_worker mdworker mdworker_shared || true
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up uv package manager
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -96,7 +96,7 @@ jobs:
             matrix.os == inputs.operating_system_for_codecov &&
             matrix.python-version == inputs.python_version_for_codecov
           }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           token: ${{ env.CODECOV_TOKEN }}
           files: coverage-unit.xml

--- a/.github/workflows/release_marker.yaml
+++ b/.github/workflows/release_marker.yaml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-22.04-arm64
     steps:
       - name: mark release
-        uses: frankie567/grafana-annotation-action@v1.0.3
+        uses: frankie567/grafana-annotation-action@36ec3b43d55fdebbec9dbff9ce1578f4b2f3ad45 # v1.0.3
         with:
           apiHost: https://grafana.apify.dev
           apiToken: ${{ secrets.grafanaApiToken}}
@@ -71,11 +71,11 @@ jobs:
     runs-on: ubuntu-22.04-arm64
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: mark deploy - frontend
         if: inputs.sentryEnvironmentFrontend != ''
-        uses: getsentry/action-release@v3
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.sentryAuthToken }}
           SENTRY_ORG: ${{ inputs.sentryOrg }}
@@ -85,7 +85,7 @@ jobs:
 
       - name: mark deploy - backend
         if: inputs.sentryEnvironmentBackend != ''
-        uses: getsentry/action-release@v3
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.sentryAuthToken }}
           SENTRY_ORG: ${{ inputs.sentryOrg }}

--- a/.github/workflows/slack.yaml
+++ b/.github/workflows/slack.yaml
@@ -62,7 +62,7 @@ jobs:
           echo "jobStatus=${jobStatus}" >> $GITHUB_OUTPUT
 
       - name: send message
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.slackToken }}

--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -39,7 +39,7 @@ jobs:
         run: npm i @octokit/rest@release-19.x
 
       - name: open and merge pull request
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GIT_HUB_TOKEN: ${{ secrets.githubToken }}
         with:
@@ -84,7 +84,7 @@ jobs:
 
       - name: report failure to slack
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.slackToken }}

--- a/.github/workflows/sync_branches_push.yaml
+++ b/.github/workflows/sync_branches_push.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: report failure to slack
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.slackToken }}

--- a/.github/workflows/test_slack_bot.yml
+++ b/.github/workflows/test_slack_bot.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send test message
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Send notification to slack
         if: inputs.slackChannelId != ''
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.slackToken }}
@@ -110,11 +110,11 @@ jobs:
             }
 
       - name: clone local repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       # TODO: turn on caching
       - name: setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: ${{ inputs.nodeVersionFile }}
           registry-url: ${{ inputs.npmRegistryUrl }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: send result to slack
         if: always() && inputs.slackChannelId != ''
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           method: chat.postMessage
           token: ${{ secrets.slackToken }}


### PR DESCRIPTION
This pins every third-party action in the workflows to a full commit SHA, keeping the resolved version tag as a trailing comment. Renovate understands that convention and updates the SHA and comment together.

Same change as apify/crawlee#4051, rolled out team-wide. The trigger was the `v11` tag of `EndBug/add-and-commit` moving to a broken release that failed to load and killed the crawlee publish workflow. With SHA pins, a tag moving under us, by accident or by compromise, can't break or hijack CI anymore. Where `EndBug/add-and-commit` is used, it's pinned to v11.0.0, the last working release.

Own-org references (`apify/*`) stay on floating refs on purpose, since we control those repos.
