### PR TITLE
feat: skip role chaining when awsRoleArn is empty

### DIFF
--- a/.github/workflows/build_docker_image_and_push_to_ecr.yaml
+++ b/.github/workflows/build_docker_image_and_push_to_ecr.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       awsRoleArn:
-        description: AWS IAM role ARN
+        description: AWS IAM role ARN to chain-assume after the OIDC role. Empty means no chaining.
         required: false
         type: string
       useOIDC:
@@ -188,7 +188,7 @@ jobs:
 
       # Then assume Deployer role, which can be assumed by GithubOIDCRole and has all the permissions needed to deploy cloudformation stacks.
       - name: assume Deployer role
-        if: inputs.useOIDC == true
+        if: inputs.useOIDC == true && inputs.awsRoleArn != ''
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-region: ${{ inputs.awsRegion }}


### PR DESCRIPTION
The `assume Deployer role` step runs whenever `useOIDC: true`, so a caller whose OIDC role already carries the permissions has no way to use OIDC - the step fails with an empty `role-to-assume`. Skipping it when `awsRoleArn` is empty lets a purpose-scoped OIDC role push directly, without standing up a second role just to satisfy the chain.

- No change for current callers: all of them pass a non-empty `awsRoleArn`.
- An ARN that resolves empty by mistake now silently skips the chain instead of failing at the assume step, so the input description says what empty means.
- First consumer is apify/apify-integrations-backend#620, where `GithubIntegrationsOIDCRole` is scoped to `ecr:*` on the integrations repositories.
