### PR TITLE
fix: pick merge method sync_branches actually allows

### DIFF
--- a/.github/workflows/sync_branches.yaml
+++ b/.github/workflows/sync_branches.yaml
@@ -75,11 +75,26 @@ jobs:
 
             const pullRequestNumber = createResp.data.number;
 
+            // Octokit defaults pulls.merge() to a real merge commit, which 405s on a
+            // repository configured to disallow merge commits. Pick the first method
+            // the repo actually allows, preferring a merge commit when it is allowed
+            // so existing callers keep their current behavior.
+            const repoResp = await serviceAccountOctokit.rest.repos.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+            });
+            const mergeMethod = repoResp.data.allow_merge_commit
+                ? 'merge'
+                : repoResp.data.allow_squash_merge
+                    ? 'squash'
+                    : 'rebase';
+
             // Merge pull request
             await serviceAccountOctokit.rest.pulls.merge({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pullRequestNumber,
+                merge_method: mergeMethod,
             });
 
       - name: report failure to slack


### PR DESCRIPTION
## What
`sync_branches.yaml`'s merge step now reads the repo's allowed merge
methods (`allow_merge_commit`/`allow_squash_merge`/`allow_rebase_merge`)
and passes the first available as `merge_method`, preferring `merge` so
existing callers see no behavior change.

## Why
`pulls.merge()` defaults to a merge commit. On any repo configured to
disallow merge commits the API 405s with "Merge commits are not allowed
on this repository", and the sync job fails outright — no PR ever gets
merged, so the branches drift.

Hit in apify/apify-ai-agent: apify/apify-ai-agent#81 failed on this,
went stale/conflicting, worked around manually in
apify/apify-ai-agent#82.

## Testing
No test harness covers the embedded `github-script` block. Verified the
script is syntactically valid (`node --check`) and diffed the change
down to a 15-line, backward-compatible addition.